### PR TITLE
181 maven push fails to create release

### DIFF
--- a/.github/workflows/maven-central-push.yml
+++ b/.github/workflows/maven-central-push.yml
@@ -70,7 +70,9 @@ jobs:
 
       - name: Maven version
         id: get-version
-        run: echo ::set-output name=version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+        run:  |
+          cd scs-multiapi-maven-plugin
+          echo name=version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) | tee $GITHUB_OUTPUT
      
       - name: Create a Release
         uses: marvinpinto/action-automatic-releases@latest
@@ -78,4 +80,4 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: ${{ steps.get-version.outputs.version }}
           prerelease: false
-          title: "Mavem Release ${{ steps.get-version.outputs.version }}"
+          title: "Maven Release ${{ steps.get-version.outputs.version }}"

--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>4.4.0</version>
+  <version>4.4.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '4.4.0'
+version = '4.4.1'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -30,7 +30,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:4.4.0'
+  implementation 'com.sngular:multiapi-engine:4.4.1'
   testImplementation 'org.assertj:assertj-core:3.23.1'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.3.1'
 }
@@ -98,7 +98,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:4.4.0'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:4.4.1'
         implementation 'org.assertj:assertj-core:3.23.1'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>4.4.0</version>
+  <version>4.4.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>4.4.0</version>
+      <version>4.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Fixes #181. Updated output to use the `$GITHUB_OUTPUT` environment variable, as `::set-output` is deprecated.