### PR TITLE
#193 Update actions to check tags

### DIFF
--- a/.github/workflows/gradle-portal-push.yml
+++ b/.github/workflows/gradle-portal-push.yml
@@ -2,32 +2,45 @@ name: Java CI with Gradle (Push)
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
+  check-pr-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      labels: ${{ steps.get-pr.outputs.pr_labels }}
+    steps:
+      - name: Get Pull Request information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: get-pr
+
   check-version:
     runs-on: ubuntu-latest
+    needs: [check-pr-labels]
+    if: contains(needs.check-pr-labels.outputs.labels, 'release')
     steps:
-    - uses: actions/checkout@v3
-    - name: Check if version is updated
-      uses: avides/actions-project-version-check@v1.3
-      id: engine_version_check
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        file-to-check: multiapi-engine/pom.xml
-      continue-on-error: true
-    - name: Check if Package Version Published
-      id: version_check
-      uses: jyeany/version-check-gradle@1.0.4
-      with:
-        organization: 'com.sngular'
-        access-token: ${{ secrets.GITHUB_TOKEN }}
-      continue-on-error: true
-  build:
+      - uses: actions/checkout@v3
+      - name: Check if version is updated
+        uses: avides/actions-project-version-check@v1.3
+        id: engine_version_check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          file-to-check: multiapi-engine/pom.xml
+        continue-on-error: true
+      - name: Check if Package Version Published
+        id: version_check
+        uses: jyeany/version-check-gradle@1.0.4
+        with:
+          organization: "com.sngular"
+          access-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
+  build:
     runs-on: ubuntu-latest
-    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
-    needs: [check-version]
+    needs: [check-version, check-pr-labels]
+    if: contains(needs.check-pr-labels.outputs.labels, 'release') && contains(needs.check-version.result, 'success')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -36,8 +49,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: "11"
+          distribution: "adopt"
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
@@ -50,7 +63,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build Engine Plugin
-        run:  |
+        run: |
           cd multiapi-engine
           mvn -B install
 

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,14 +1,14 @@
 name: Greetings
 
-on: [ pull_request, issues ]
+on: [pull_request, issues]
 
 jobs:
   greeting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/first-interaction@v1
-      continue-on-error: true
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'Thank you for collaborating with the project by giving us feedback!!'' Cheers'
-        pr-message: 'Thank you for collaborating with the project to help us to improve!!'''
+      - uses: actions/first-interaction@v1
+        continue-on-error: true
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: "Thank you for collaborating with the project by giving us feedback! Cheers!"
+          pr-message: "Thank you for collaborating with the project to help us improve!"

--- a/.github/workflows/maven-central-push.yml
+++ b/.github/workflows/maven-central-push.yml
@@ -2,33 +2,45 @@ name: Java CI with Maven (Push)
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
+  check-pr-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      labels: ${{ steps.get-pr.outputs.pr_labels }}
+    steps:
+      - name: Get Pull Request information
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: get-pr
+
   check-version:
     runs-on: ubuntu-latest
+    needs: [check-pr-labels]
+    if: contains(needs.check-pr-labels.outputs.labels, 'release')
     steps:
-    - uses: actions/checkout@v3
-    - name: Check if version is updated
-      uses: avides/actions-project-version-check@v1.3
-      id: engine_version_check
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        file-to-check: multiapi-engine/pom.xml
-      continue-on-error: true
-    - name: Check if version is updated
-      uses: avides/actions-project-version-check@v1.3
-      id: maven_plugin_version_check
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        file-to-check: scs-multiapi-maven-plugin/pom.xml
-      continue-on-error: true
+      - uses: actions/checkout@v3
+      - name: Check if version is updated
+        uses: avides/actions-project-version-check@v1.3
+        id: engine_version_check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          file-to-check: multiapi-engine/pom.xml
+        continue-on-error: true
+      - name: Check if version is updated
+        uses: avides/actions-project-version-check@v1.3
+        id: maven_plugin_version_check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          file-to-check: scs-multiapi-maven-plugin/pom.xml
+        continue-on-error: true
 
   build:
-
     runs-on: ubuntu-latest
-    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
-    needs: [check-version]
+    needs: [check-version, check-pr-labels]
+    if: contains(needs.check-pr-labels.outputs.labels, 'release') && contains(needs.check-version.result, 'success')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -37,8 +49,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: "11"
+          distribution: "adopt"
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
@@ -51,7 +63,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build Engine Plugin
-        run:  |
+        run: |
           cd multiapi-engine
           mvn -B install
 
@@ -70,10 +82,10 @@ jobs:
 
       - name: Maven version
         id: get-version
-        run:  |
+        run: |
           cd scs-multiapi-maven-plugin
           echo "version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" | tee $GITHUB_OUTPUT
-     
+
       - name: Create a Release
         uses: marvinpinto/action-automatic-releases@latest
         with:

--- a/.github/workflows/maven-pr-review.yml
+++ b/.github/workflows/maven-pr-review.yml
@@ -1,0 +1,18 @@
+name: Pull Request Approved
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.mergeable == true && github.event.review.state == 'approved'
+    steps:
+      - name: Warn about missing labels
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'release') && !contains(github.event.pull_request.labels.*.name, 'documentation') }}
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: "This pull request hasn't been labeled as `release` nor `documentation`. Please ensure this is intentional before merging."
+          comment_tag: label-warn

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -2,67 +2,80 @@ name: Java CI with Maven (PR)
 
 on:
   pull_request:
-    types: synchronize
+    types: [opened, synchronize, ready_for_review, review_requested, labeled]
 
 jobs:
   check-version:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'release')
     steps:
-    - uses: actions/checkout@v3
-    - name: Check if version is updated
-      uses: avides/actions-project-version-check@v1.3
-      id: engine_version_check
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        file-to-check: multiapi-engine/pom.xml
-      continue-on-error: true
-    - name: Check if version is updated
-      uses: avides/actions-project-version-check@v1.3
-      id: maven_plugin_version_check
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        file-to-check: scs-multiapi-maven-plugin/pom.xml
-      continue-on-error: true
-    - name: Versioning specifications
-      if: steps.engine_version_check.outcome != 'success' && steps.maven_plugin_version_check.outcome != 'success'
-      uses: thollander/actions-comment-pull-request@v1
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        message: Project version has not been updated in pom.xml. Please, update your version using https://semver.org specifications
-    - name: Exit if fails
-      if: steps.engine_version_check.outcome != 'success' || steps.maven_plugin_version_check.outcome != 'success'
-      uses: cutenode/action-always-fail@v1
-    - name: New software version
-      if: steps.engine_version_check.outcome == 'success' && steps.maven_plugin_version_check.outcome == 'success'
-      run: echo "New multiapi engine version is " ${{ steps.engine_version_check.outputs.version }}
-      
+      - uses: actions/checkout@v3
+      - name: Check if version is updated
+        uses: avides/actions-project-version-check@v1.3
+        id: engine_version_check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          file-to-check: multiapi-engine/pom.xml
+        continue-on-error: true
+      - name: Check if version is updated
+        uses: avides/actions-project-version-check@v1.3
+        id: maven_plugin_version_check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          file-to-check: scs-multiapi-maven-plugin/pom.xml
+        continue-on-error: true
+      - name: Warn about version specification
+        if: steps.engine_version_check.outcome != 'success' && steps.maven_plugin_version_check.outcome != 'success'
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: Project version has not been updated in pom.xml. Please, update your version using https://semver.org specifications
+      - name: Fail
+        if: steps.engine_version_check.outcome != 'success' || steps.maven_plugin_version_check.outcome != 'success'
+        uses: cutenode/action-always-fail@v1
+      - name: New software version
+        if: steps.engine_version_check.outcome == 'success' && steps.maven_plugin_version_check.outcome == 'success'
+        run: echo "New multiapi engine version is " ${{ steps.engine_version_check.outputs.version }}
+
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Build Engine Plugin
-      run:  |
-        cd multiapi-engine
-        mvn -B install
-    - name: Build Maven Plugin
-      # Uses production profile to sign with gpg plugin
-      run: |
-        cd scs-multiapi-maven-plugin
-        mvn -P production -B test
-    - name: Build Gradle Plugin
-      run: |
-        cd scs-multiapi-gradle-plugin
-        gradle wrapper
-        chmod +x gradlew
-        ./gradlew build
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build Engine Plugin
+        run: |
+          cd multiapi-engine
+          mvn -B install
+      - name: Build Maven Plugin
+        # Uses production profile to sign with gpg plugin
+        run: |
+          cd scs-multiapi-maven-plugin
+          mvn -P production -B test
+      - name: Build Gradle Plugin
+        run: |
+          cd scs-multiapi-gradle-plugin
+          gradle wrapper
+          chmod +x gradlew
+          ./gradlew build
+          
+  check-labels:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.mergeable == true
+    steps:
+      - name: Warn about missing labels
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'release') && !contains(github.event.pull_request.labels.*.name, 'documentation') }}
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: "This pull request hasn't been labeled as `release` nor `documentation`. Please ensure this is intentional before merging."
+          comment_tag: label-warn


### PR DESCRIPTION
Closes #193. Also warns in a comment if a PR is ready to merge but has no labels.

This repo had no actions related to updating the wiki, unlike kloadgen's. Do we want to add that functionality?