### PR TITLE
Fix generation when consumers/producers are missing from SpecFile

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>4.5.1</version>
+  <version>4.5.2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGenerator.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGenerator.java
@@ -211,7 +211,7 @@ public class AsyncApiGenerator {
                                  if (payload.has(REF)) {
                                    payload = payload.get(REF);
                                  }
-                                 totalSchemas.put(key, payload);
+                                 totalSchemas.putIfAbsent(key, payload);
                                }
                              })
     );

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGenerator.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGenerator.java
@@ -116,11 +116,9 @@ public class AsyncApiGenerator {
   }
 
   public final void processFileSpec(final List<SpecFile> specsListFile) {
-
     final ObjectMapper om = new ObjectMapper(new YAMLFactory());
     generateExceptionTemplate = false;
     for (SpecFile fileParameter : specsListFile) {
-      setUpTemplate(fileParameter);
       String avroFilePath = fileParameter.getFilePath();
       if (avroFilePath.startsWith(".")) {
         avroFilePath = baseDir.getAbsolutePath() + avroFilePath.replaceFirst("\\.", "");
@@ -134,7 +132,6 @@ public class AsyncApiGenerator {
         final Map<String, JsonNode> totalSchemas = getAllSchemas(ymlParentPath, node);
         final Iterator<Entry<String, JsonNode>> iter = internalNode.fields();
         while (iter.hasNext()) {
-
           final Map.Entry<String, JsonNode> entry = iter.next();
 
           final JsonNode channel = entry.getValue();
@@ -142,20 +139,46 @@ public class AsyncApiGenerator {
           final String operationId = getOperationId(channel);
           final JsonNode channelPayload = getChannelPayload(channel);
 
+          handleMissingPublisherConsumer(fileParameter, channel, operationId);
+
           processOperation(fileParameter, ymlParentPath, entry, channel, operationId, channelPayload, totalSchemas);
-
-          if (ObjectUtils.allNull(fileParameter.getConsumer(), fileParameter.getSupplier(), fileParameter.getStreamBridge())) {
-            final String className = channel.has(SUBSCRIBE) ? CONSUMER_CLASS_NAME : SUPPLIER_CLASS_NAME;
-            checkClassPackageDuplicate(className, DEFAULT_ASYNCAPI_API_PACKAGE);
-            processSupplierMethod(channelPayload, null, ymlParentPath, totalSchemas, false, "", "DTO");
-            addProcessedClassesAndPackagesToGlobalVariables(null, DEFAULT_ASYNCAPI_API_PACKAGE, className);
-          }
-
         }
+
+        setUpTemplate(fileParameter);
         templateFactory.fillTemplates();
         templateFactory.clearData();
       } catch (final TemplateException | IOException e) {
         e.printStackTrace();
+      }
+    }
+  }
+
+  private void handleMissingPublisherConsumer(final SpecFile fileParameter, final JsonNode channel, final String operationId) {
+    if (channel.has(SUBSCRIBE) && ObjectUtils.allNull(fileParameter.getConsumer(), fileParameter.getStreamBridge())) {
+      try {
+        checkClassPackageDuplicate(CONSUMER_CLASS_NAME, DEFAULT_ASYNCAPI_API_PACKAGE);
+        fileParameter.setConsumer(
+            OperationParameterObject.builder()
+                                    .ids(operationId)
+                                    .apiPackage(DEFAULT_ASYNCAPI_API_PACKAGE)
+                                    .modelPackage(DEFAULT_ASYNCAPI_MODEL_PACKAGE)
+                                    .build());
+      } catch (final DuplicateClassException ignored) {
+        // Don't set consumer
+      }
+    }
+
+    if (channel.has(PUBLISH) && ObjectUtils.allNull(fileParameter.getSupplier(), fileParameter.getStreamBridge())) {
+      try {
+        checkClassPackageDuplicate(SUPPLIER_CLASS_NAME, DEFAULT_ASYNCAPI_API_PACKAGE);
+        fileParameter.setSupplier(
+            OperationParameterObject.builder()
+                                    .ids(operationId)
+                                    .apiPackage(DEFAULT_ASYNCAPI_API_PACKAGE)
+                                    .modelPackage(DEFAULT_ASYNCAPI_MODEL_PACKAGE)
+                                    .build());
+      } catch (final DuplicateClassException ignored) {
+        // Don't set supplier
       }
     }
   }
@@ -179,24 +202,22 @@ public class AsyncApiGenerator {
   private Map<String, JsonNode> getAllSchemas(final Path ymlParentPath, final JsonNode node) {
     final Map<String, JsonNode> totalSchemas = new HashMap<>();
     final List<JsonNode> referenceList = node.findValues(REF);
-    referenceList.forEach(reference ->
-        processReference(node, reference, ymlParentPath, totalSchemas, referenceList)
-    );
+    referenceList.forEach(reference -> processReference(node, reference, ymlParentPath, totalSchemas, referenceList));
     final List<JsonNode> messagesList = node.findValues(MESSAGES);
     final List<JsonNode> schemasList = node.findValues(SCHEMAS);
-    schemasList.forEach(schema -> schema.fields().forEachRemaining(fieldSchema -> totalSchemas.putIfAbsent((SCHEMAS + SLASH + fieldSchema.getKey()).toUpperCase(),
-                                                                   fieldSchema.getValue())));
+    schemasList.forEach(
+        schema -> schema.fields().forEachRemaining(fieldSchema -> totalSchemas.putIfAbsent((SCHEMAS + SLASH + fieldSchema.getKey()).toUpperCase(), fieldSchema.getValue())));
     messagesList.forEach(message ->
-                           message.fields().forEachRemaining(fieldSchema -> {
-                             if (fieldSchema.getValue().has(PAYLOAD)) {
-                               final var payload = fieldSchema.getValue().get(PAYLOAD);
-                               if (!payload.has(REF)) {
-                                 totalSchemas.put((MESSAGES + SLASH + fieldSchema.getKey()).toUpperCase(), payload);
-                               } else {
-                                 totalSchemas.putIfAbsent((MESSAGES + SLASH + fieldSchema.getKey()).toUpperCase(), payload.get(REF));
+                             message.fields().forEachRemaining(fieldSchema -> {
+                               if (fieldSchema.getValue().has(PAYLOAD)) {
+                                 final var payload = fieldSchema.getValue().get(PAYLOAD);
+                                 if (!payload.has(REF)) {
+                                   totalSchemas.put((MESSAGES + SLASH + fieldSchema.getKey()).toUpperCase(), payload);
+                                 } else {
+                                   totalSchemas.putIfAbsent((MESSAGES + SLASH + fieldSchema.getKey()).toUpperCase(), payload.get(REF));
+                                 }
                                }
-                             }
-                           })
+                             })
     );
     return totalSchemas;
   }
@@ -223,7 +244,8 @@ public class AsyncApiGenerator {
     return returnNode;
   }
 
-  private void processReference(final JsonNode node, final JsonNode reference, final Path ymlParentPath, final Map<String, JsonNode> totalSchemas,
+  private void processReference(
+      final JsonNode node, final JsonNode reference, final Path ymlParentPath, final Map<String, JsonNode> totalSchemas,
       final List<JsonNode> referenceList) {
     final String referenceLink = reference.asText();
     final String[] path = MapperUtil.splitName(referenceLink);
@@ -249,7 +271,8 @@ public class AsyncApiGenerator {
     }
   }
 
-  private void checkReference(final JsonNode mainNode, final JsonNode node, final Path ymlParentPath, final Map<String, JsonNode> totalSchemas,
+  private void checkReference(
+      final JsonNode mainNode, final JsonNode node, final Path ymlParentPath, final Map<String, JsonNode> totalSchemas,
       final List<JsonNode> referenceList) {
     final var localReferences = node.findValues(REF);
     if (!localReferences.isEmpty()) {
@@ -410,14 +433,16 @@ public class AsyncApiGenerator {
     return evaluated;
   }
 
-  private void processSupplierMethod(final JsonNode channel, final String modelPackage, final Path ymlParentPath, final Map<String, JsonNode> totalSchemas,
+  private void processSupplierMethod(
+      final JsonNode channel, final String modelPackage, final Path ymlParentPath, final Map<String, JsonNode> totalSchemas,
       final boolean usingLombok, final String prefix, final String suffix) throws IOException, TemplateException {
     final Pair<String, String> result = processMethod(channel, Objects.isNull(modelPackage) ? null : modelPackage, ymlParentPath, prefix, suffix);
     fillTemplateFactory(result.getValue(), totalSchemas, usingLombok, suffix, modelPackage);
     templateFactory.addSupplierMethod(result.getKey(), result.getValue());
   }
 
-  private void processStreamBridgeMethod(final JsonNode channel, final String modelPackage, final Path ymlParentPath, final String channelName,
+  private void processStreamBridgeMethod(
+      final JsonNode channel, final String modelPackage, final Path ymlParentPath, final String channelName,
       final Map<String, JsonNode> totalSchemas, final boolean usingLombok, final String prefix, final String suffix) throws IOException, TemplateException {
     final Pair<String, String> result = processMethod(channel, Objects.isNull(modelPackage) ? null : modelPackage, ymlParentPath, prefix, suffix);
     final String regex = "[a-zA-Z0-9.\\-]*";
@@ -428,14 +453,16 @@ public class AsyncApiGenerator {
     templateFactory.addStreamBridgeMethod(result.getKey(), result.getValue(), channelName);
   }
 
-  private void processSubscribeMethod(final JsonNode channel, final String modelPackage, final Path ymlParentPath, final Map<String, JsonNode> totalSchemas,
+  private void processSubscribeMethod(
+      final JsonNode channel, final String modelPackage, final Path ymlParentPath, final Map<String, JsonNode> totalSchemas,
       final boolean usingLombok, final String prefix, final String suffix) throws IOException, TemplateException {
     final Pair<String, String> result = processMethod(channel, Objects.isNull(modelPackage) ? null : modelPackage, ymlParentPath, prefix, suffix);
     fillTemplateFactory(result.getValue(), totalSchemas, usingLombok, suffix, modelPackage);
     templateFactory.addSubscribeMethod(result.getKey(), result.getValue());
   }
 
-  private void fillTemplateFactory(final String classFullName, final Map<String, JsonNode> totalSchemas, final boolean usingLombok, final String classSuffix,
+  private void fillTemplateFactory(
+      final String classFullName, final Map<String, JsonNode> totalSchemas, final boolean usingLombok, final String classSuffix,
       final String modelPackageReceived)
       throws TemplateException, IOException {
     final var modelPackage = classFullName.substring(0, classFullName.lastIndexOf("."));

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '4.5.1'
+version = '4.5.2'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -30,7 +30,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:4.5.1'
+  implementation 'com.sngular:multiapi-engine:4.5.2'
   testImplementation 'org.assertj:assertj-core:3.23.1'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.3.1'
 }
@@ -98,7 +98,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:4.5.1'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:4.5.2'
         implementation 'org.assertj:assertj-core:3.23.1'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>4.5.1</version>
+  <version>4.5.2</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -165,6 +165,17 @@
       </roles>
       <timezone>Europe/Madrid</timezone>
     </developer>
+    <developer>
+      <id>5uso-sng</id>
+      <name>Jesús Mosteiro García</name>
+      <email>jesus.mosteiro@sngular.com</email>
+      <organization>Sngular</organization>
+      <organizationUrl>https://www.sngular.com</organizationUrl>
+      <roles>
+        <role>Software Developer - Trainee</role>
+      </roles>
+      <timezone>Europe/Madrid</timezone>
+    </developer>
   </developers>
 
   <scm>
@@ -212,7 +223,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>4.5.1</version>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest.java
+++ b/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 public class AsyncApiGenerationTest {
 
   @MavenTest
-  @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:asyncapi-generation")
   void testFileGenerationTwoYmlFiles(MavenProjectResult result) throws IOException {
     List<String> expectedFirstYmlFileNames = List.of("IPublishOperation.java", "ISubscribeOperation.java", "Producer.java", "Subscriber.java");
 

--- a/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest.java
+++ b/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest.java
@@ -15,8 +15,10 @@ import java.nio.file.Path;
 import java.util.List;
 
 import com.sngular.api.generator.test.utils.TestUtils;
+import com.soebes.itf.jupiter.extension.MavenDebug;
 import com.soebes.itf.jupiter.extension.MavenGoal;
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenOptions;
 import com.soebes.itf.jupiter.extension.MavenRepository;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.maven.MavenProjectResult;
@@ -47,8 +49,8 @@ public class AsyncApiGenerationTest {
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
 
-    Path pathToTargetFirstYml = pathToTarget.resolve("target/generated-sources/apigenerator/com/sngular");
-    Path pathToTargetSecondYml = pathToTarget.resolve("target/generated-sources/apigenerator/com/sngular/generator/multiapi/model/event/producer2");
+    Path pathToTargetFirstYml = pathToTarget.resolve("target/generated-sources/apigenerator/com/sngular/apigenerator/asyncapi");
+    Path pathToTargetSecondYml = pathToTarget.resolve("target/generated-sources/apigenerator/com/sngular/apigenerator/asyncapi/producer2");
 
     File targetFirstYmlDirectory = pathToTargetFirstYml.toFile();
     File targetSecondYmlDirectory = pathToTargetSecondYml.toFile();

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/IPublishOperation.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/IPublishOperation.java
@@ -1,6 +1,6 @@
 package com.sngular;
 
-import com.sngular.apigenerator.asyncapi.OrderCreated;
+import com.sngular.apigenerator.asyncapi.messages.OrderCreated;
 
 public interface IPublishOperation {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/IPublishOperation.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/IPublishOperation.java
@@ -1,6 +1,6 @@
-package com.sngular;
+package com.sngular.apigenerator.asyncapi;
 
-import com.sngular.apigenerator.asyncapi.messages.OrderCreated;
+import com.sngular.apigenerator.asyncapi.model.messages.OrderCreated;
 
 public interface IPublishOperation {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/ISubscribeOperation.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/ISubscribeOperation.java
@@ -1,6 +1,6 @@
 package com.sngular;
 
-import com.sngular.apigenerator.asyncapi.CreateOrder;
+import com.sngular.apigenerator.asyncapi.messages.CreateOrder;
 
 public interface ISubscribeOperation {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/ISubscribeOperation.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/ISubscribeOperation.java
@@ -1,6 +1,6 @@
-package com.sngular;
+package com.sngular.apigenerator.asyncapi;
 
-import com.sngular.apigenerator.asyncapi.messages.CreateOrder;
+import com.sngular.apigenerator.asyncapi.model.messages.CreateOrder;
 
 public interface ISubscribeOperation {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/Producer.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/Producer.java
@@ -4,7 +4,7 @@ import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.apigenerator.asyncapi.OrderCreated;
+import com.sngular.apigenerator.asyncapi.messages.OrderCreated;
 
 @Configuration
 public class Producer {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/Producer.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/Producer.java
@@ -1,10 +1,10 @@
-package com.sngular;
+package com.sngular.apigenerator.asyncapi;
 
 import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.apigenerator.asyncapi.messages.OrderCreated;
+import com.sngular.apigenerator.asyncapi.model.messages.OrderCreated;
 
 @Configuration
 public class Producer {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/Subscriber.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/Subscriber.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.apigenerator.asyncapi.CreateOrder;
+import com.sngular.apigenerator.asyncapi.messages.CreateOrder;
 
 @Configuration
 public class Subscriber {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/Subscriber.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/Subscriber.java
@@ -1,10 +1,10 @@
-package com.sngular;
+package com.sngular.apigenerator.asyncapi;
 
 import java.util.function.Consumer;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.apigenerator.asyncapi.messages.CreateOrder;
+import com.sngular.apigenerator.asyncapi.model.messages.CreateOrder;
 
 @Configuration
 public class Subscriber {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/producer2/IPublishOperation2.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/producer2/IPublishOperation2.java
@@ -1,6 +1,6 @@
-package com.sngular.generator.multiapi.model.event.producer2;
+package com.sngular.apigenerator.asyncapi.producer2;
 
-import com.sngular.generator.multiapi.model.event.messages.OrderCreatedDTO;
+import com.sngular.apigenerator.asyncapi.model.messages.OrderCreatedDTO;
 
 public interface IPublishOperation2 {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/producer2/IPublishOperation2.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/producer2/IPublishOperation2.java
@@ -1,6 +1,6 @@
 package com.sngular.generator.multiapi.model.event.producer2;
 
-import com.sngular.generator.multiapi.model.event.OrderCreatedDTO;
+import com.sngular.generator.multiapi.model.event.messages.OrderCreatedDTO;
 
 public interface IPublishOperation2 {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/producer2/Producer.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/producer2/Producer.java
@@ -4,7 +4,7 @@ import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.generator.multiapi.model.event.OrderCreatedDTO;
+import com.sngular.generator.multiapi.model.event.messages.OrderCreatedDTO;
 
 @Configuration
 public class Producer {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/producer2/Producer.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/assets/producer2/Producer.java
@@ -1,10 +1,10 @@
-package com.sngular.generator.multiapi.model.event.producer2;
+package com.sngular.apigenerator.asyncapi.producer2;
 
 import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.generator.multiapi.model.event.messages.OrderCreatedDTO;
+import com.sngular.apigenerator.asyncapi.model.messages.OrderCreatedDTO;
 
 @Configuration
 public class Producer {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/event-api.yml
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/event-api.yml
@@ -20,12 +20,12 @@ servers:
     protocol: kafka
     protocolVersion: 0.9.1
 channels:
-  order/created:
+  order.created:
     publish:
       operationId: "publishOperation"
       message:
         $ref: '#/components/messages/OrderCreated'
-  order/createCommand:
+  order.createCommand:
     subscribe:
       operationId: "subscribeOperation"
       message:

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/pom.xml
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/pom.xml
@@ -32,28 +32,39 @@
         <artifactId>scs-multiapi-maven-plugin</artifactId>
         <executions>
           <execution>
+            <id>asyncapi</id>
             <phase>generate-sources</phase>
             <goals>
               <goal>asyncapi-generation</goal>
             </goals>
+            <configuration>
+              <specFiles>
+                <specFile>
+                  <filePath>event-api.yml</filePath>
+                  <consumer>
+                    <ids>subscribeOperation</ids>
+                    <apiPackage>com.sngular</apiPackage>
+                    <modelPackage>com.sngular.apigenerator.asyncapi</modelPackage>
+                  </consumer>
+                  <supplier>
+                    <ids>publishOperation</ids>
+                    <apiPackage>com.sngular</apiPackage>
+                    <modelPackage>com.sngular.apigenerator.asyncapi</modelPackage>
+                  </supplier>
+                </specFile>
+                <specFile>
+                  <filePath>event-api2.yml</filePath>
+                  <supplier>
+                    <ids>publishOperation2</ids>
+                    <modelNameSuffix>DTO</modelNameSuffix>
+                    <apiPackage>com.sngular.generator.multiapi.model.event.producer2</apiPackage>
+                    <modelPackage>com.sngular.generator.multiapi.model.event</modelPackage>
+                  </supplier>
+                </specFile>
+              </specFiles>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <specFiles>
-            <specFile>
-              <filePath>event-api.yml</filePath>
-            </specFile>
-            <specFile>
-              <filePath>event-api2.yml</filePath>
-              <supplier>
-                <ids>publishOperation2</ids>
-                <modelNameSuffix>DTO</modelNameSuffix>
-                <apiPackage>com.sngular.generator.multiapi.model.event.producer2</apiPackage>
-                <modelPackage>com.sngular.generator.multiapi.model.event</modelPackage>
-              </supplier>
-            </specFile>
-          </specFiles>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/pom.xml
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationTest/testFileGenerationTwoYmlFiles/pom.xml
@@ -41,24 +41,14 @@
               <specFiles>
                 <specFile>
                   <filePath>event-api.yml</filePath>
-                  <consumer>
-                    <ids>subscribeOperation</ids>
-                    <apiPackage>com.sngular</apiPackage>
-                    <modelPackage>com.sngular.apigenerator.asyncapi</modelPackage>
-                  </consumer>
-                  <supplier>
-                    <ids>publishOperation</ids>
-                    <apiPackage>com.sngular</apiPackage>
-                    <modelPackage>com.sngular.apigenerator.asyncapi</modelPackage>
-                  </supplier>
                 </specFile>
                 <specFile>
                   <filePath>event-api2.yml</filePath>
                   <supplier>
                     <ids>publishOperation2</ids>
                     <modelNameSuffix>DTO</modelNameSuffix>
-                    <apiPackage>com.sngular.generator.multiapi.model.event.producer2</apiPackage>
-                    <modelPackage>com.sngular.generator.multiapi.model.event</modelPackage>
+                    <apiPackage>com.sngular.apigenerator.asyncapi.producer2</apiPackage>
+                    <modelPackage>com.sngular.apigenerator.asyncapi.model</modelPackage>
                   </supplier>
                 </specFile>
               </specFiles>

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ApiErrorDTO.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ApiErrorDTO.java
@@ -2,11 +2,14 @@ package com.sngular.generator.multiapi.rest.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.sngular.generator.multiapi.rest.model.exception.ModelClassException;
 import com.sngular.generator.multiapi.rest.model.customvalidator.NotNull;
 
+@JsonDeserialize(builder = ApiErrorDTO.ApiErrorDTOBuilder.class)
 public class ApiErrorDTO {
 
   @JsonProperty(value ="code")
@@ -34,6 +37,7 @@ public class ApiErrorDTO {
     return new ApiErrorDTO.ApiErrorDTOBuilder();
   }
 
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class ApiErrorDTOBuilder {
 
     private Integer code;

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ApiTestDTO.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ApiTestDTO.java
@@ -2,11 +2,14 @@ package com.sngular.generator.multiapi.rest.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.sngular.generator.multiapi.rest.model.exception.ModelClassException;
 import com.sngular.generator.multiapi.rest.model.customvalidator.NotNull;
 
+@JsonDeserialize(builder = ApiTestDTO.ApiTestDTOBuilder.class)
 public class ApiTestDTO {
 
   @JsonProperty(value ="name")
@@ -34,6 +37,7 @@ public class ApiTestDTO {
     return new ApiTestDTO.ApiTestDTOBuilder();
   }
 
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class ApiTestDTOBuilder {
 
     private String name;

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ApiTestInfoDTO.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ApiTestInfoDTO.java
@@ -2,6 +2,8 @@ package com.sngular.generator.multiapi.rest.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -9,6 +11,7 @@ import java.util.ArrayList;
 import com.sngular.generator.multiapi.rest.model.exception.ModelClassException;
 import com.sngular.generator.multiapi.rest.model.customvalidator.NotNull;
 
+@JsonDeserialize(builder = ApiTestInfoDTO.ApiTestInfoDTOBuilder.class)
 public class ApiTestInfoDTO {
 
   @JsonProperty(value ="testers")
@@ -35,6 +38,7 @@ public class ApiTestInfoDTO {
     return new ApiTestInfoDTO.ApiTestInfoDTOBuilder();
   }
 
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class ApiTestInfoDTOBuilder {
 
     private List<String> testers = new ArrayList<String>();

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/IPublishOperation.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/IPublishOperation.java
@@ -1,6 +1,6 @@
 package com.sngular.generator.multiapi.model.event.consumer;
 
-import com.sngular.generator.multiapi.model.event.OrderCreatedDTO;
+import com.sngular.generator.multiapi.model.event.messages.OrderCreatedDTO;
 
 public interface IPublishOperation {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ISubscribeOperation.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ISubscribeOperation.java
@@ -1,6 +1,6 @@
 package com.sngular.generator.multiapi.model.event.producer;
 
-import com.sngular.generator.multiapi.model.event.CreateOrderMapper;
+import com.sngular.generator.multiapi.model.event.messages.CreateOrderMapper;
 
 public interface ISubscribeOperation {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/Producer.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/Producer.java
@@ -4,7 +4,7 @@ import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.generator.multiapi.model.event.CreateOrderMapper;
+import com.sngular.generator.multiapi.model.event.messages.CreateOrderMapper;
 
 @Configuration
 public class Producer {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/TestClassName.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/TestClassName.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.generator.multiapi.model.event.OrderCreatedDTO;
+import com.sngular.generator.multiapi.model.event.messages.OrderCreatedDTO;
 
 @Configuration
 public class TestClassName {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ApiErrorDTO.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ApiErrorDTO.java
@@ -2,11 +2,14 @@ package com.sngular.generator.multiapi.rest.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.sngular.generator.multiapi.rest.model.exception.ModelClassException;
 import com.sngular.generator.multiapi.rest.model.customvalidator.NotNull;
 
+@JsonDeserialize(builder = ApiErrorDTO.ApiErrorDTOBuilder.class)
 public class ApiErrorDTO {
 
   @JsonProperty(value ="code")
@@ -34,6 +37,7 @@ public class ApiErrorDTO {
     return new ApiErrorDTO.ApiErrorDTOBuilder();
   }
 
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class ApiErrorDTOBuilder {
 
     private Integer code;

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ApiTestDTO.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ApiTestDTO.java
@@ -2,11 +2,14 @@ package com.sngular.generator.multiapi.rest.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.sngular.generator.multiapi.rest.model.exception.ModelClassException;
 import com.sngular.generator.multiapi.rest.model.customvalidator.NotNull;
 
+@JsonDeserialize(builder = ApiTestDTO.ApiTestDTOBuilder.class)
 public class ApiTestDTO {
 
   @JsonProperty(value ="name")
@@ -34,6 +37,7 @@ public class ApiTestDTO {
     return new ApiTestDTO.ApiTestDTOBuilder();
   }
 
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class ApiTestDTOBuilder {
 
     private String name;

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ApiTestInfoDTO.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ApiTestInfoDTO.java
@@ -2,6 +2,8 @@ package com.sngular.generator.multiapi.rest.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -9,6 +11,7 @@ import java.util.ArrayList;
 import com.sngular.generator.multiapi.rest.model.exception.ModelClassException;
 import com.sngular.generator.multiapi.rest.model.customvalidator.NotNull;
 
+@JsonDeserialize(builder = ApiTestInfoDTO.ApiTestInfoDTOBuilder.class)
 public class ApiTestInfoDTO {
 
   @JsonProperty(value ="testers")
@@ -35,6 +38,7 @@ public class ApiTestInfoDTO {
     return new ApiTestInfoDTO.ApiTestInfoDTOBuilder();
   }
 
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class ApiTestInfoDTOBuilder {
 
     private List<String> testers = new ArrayList<String>();

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/IPublishOperation.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/IPublishOperation.java
@@ -1,6 +1,6 @@
 package com.sngular.generator.multiapi.model.event.consumer;
 
-import com.sngular.generator.multiapi.model.event.OrderCreatedDTO;
+import com.sngular.generator.multiapi.model.event.messages.OrderCreatedDTO;
 
 public interface IPublishOperation {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ISubscribeOperation.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ISubscribeOperation.java
@@ -1,6 +1,6 @@
 package com.sngular.generator.multiapi.model.event.producer;
 
-import com.sngular.generator.multiapi.model.event.CreateOrderMapper;
+import com.sngular.generator.multiapi.model.event.messages.CreateOrderMapper;
 
 public interface ISubscribeOperation {
 

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/Producer.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/Producer.java
@@ -4,7 +4,7 @@ import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.generator.multiapi.model.event.CreateOrderMapper;
+import com.sngular.generator.multiapi.model.event.messages.CreateOrderMapper;
 
 @Configuration
 public class Producer {

--- a/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/TestClassName.java
+++ b/scs-multiapi-maven-plugin/src/test/resources/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/TestClassName.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.generator.multiapi.model.event.OrderCreatedDTO;
+import com.sngular.generator.multiapi.model.event.messages.OrderCreatedDTO;
 
 @Configuration
 public class TestClassName {


### PR DESCRIPTION
Fixes #197 and #198 (as they were closely related). Mostly updates to the integration tests, but also changes how missing consumers/publishers in SpecFiles are handled. 