### PR TITLE
#222 Reenable integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ pom.xml.bak
 **/bin/
 .vscode/
 **/.java-version
+
+*.bak
+
+scs-multiapi-maven-plugin/dependency-reduced-pom.xml

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -408,7 +408,6 @@
         <configuration>
           <minimizeJar>true</minimizeJar>
           <createDependencyReducedPom>true</createDependencyReducedPom>
-          <dependencyReducedPomLocation>${project.build.directory}/pom.xml</dependencyReducedPomLocation>
           <useDependencyReducedPomInJar>true</useDependencyReducedPomInJar>
         </configuration>
         <executions>

--- a/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationIT.java
+++ b/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/asyncapi/integration/test/AsyncApiGenerationIT.java
@@ -20,14 +20,12 @@ import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
 import com.soebes.itf.jupiter.extension.MavenRepository;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.maven.MavenProjectResult;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MavenRepository
 @MavenJupiterExtension
 @Execution(ExecutionMode.SAME_THREAD)
-@Disabled("TODO: IFS Target folder problem")
 public class AsyncApiGenerationIT {
 
   @MavenTest

--- a/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationIT.java
+++ b/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/multiapi/integration/test/ScsMultiapiGenerationIT.java
@@ -20,14 +20,12 @@ import com.soebes.itf.jupiter.extension.MavenRepository;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.extension.SystemProperty;
 import com.soebes.itf.jupiter.maven.MavenProjectResult;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MavenRepository
 @MavenJupiterExtension
 @Execution(ExecutionMode.SAME_THREAD)
-@Disabled("TODO: IFS Target folder problem")
 public class ScsMultiapiGenerationIT {
 
   @MavenTest

--- a/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/openapi/integration/test/OpenApiGenerationIT.java
+++ b/scs-multiapi-maven-plugin/src/test/java/com/sngular/api/generator/openapi/integration/test/OpenApiGenerationIT.java
@@ -20,14 +20,12 @@ import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
 import com.soebes.itf.jupiter.extension.MavenRepository;
 import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.maven.MavenProjectResult;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MavenRepository
 @MavenJupiterExtension
 @Execution(ExecutionMode.SAME_THREAD)
-@Disabled("TODO: IFS Target folder problem")
 public class OpenApiGenerationIT {
 
   @MavenTest


### PR DESCRIPTION
Resolves #222. The dependency reduced pom location should be in the maven plugin project's base directory so tests know where to get their resources from