### PR TITLE
333 generated avro class imports use model package instead of avro schema namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ As commented above, they both could be used at the same time, setting a double
 <plugin>
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>5.3.6</version>
+  <version>5.4.0</version>
   <executions>
     <execution>
       <id>asyncapi</id>
@@ -114,7 +114,7 @@ Apply the plugin in the `build.gradle` file and invoke the task.
 ```groovy
 plugins {
   id "java"
-  id "com.sngular.scs-multiapi-gradle-plugin' version '5.3.6"
+  id "com.sngular.scs-multiapi-gradle-plugin' version '5.4.0"
 
   openapimodel {
 
@@ -153,7 +153,7 @@ which the plugin is designed.
 <plugin>
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>5.3.6</version>
+  <version>5.4.0</version>
   <executions>
     <execution>
       <phase>generate-sources</phase>
@@ -583,7 +583,7 @@ file. Here is an example of a basic configuration:
 <plugin>
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>5.3.6</version>
+  <version>5.4.0</version>
   <executions>
     <execution>
       <goals>

--- a/README.md
+++ b/README.md
@@ -369,8 +369,9 @@ order/createCommand:
 ```
 
 - **Namespace from Avro**: The plugin will check for a `namespace`
-  attribute defined in the Avro file and use it, if a namespace is not defined it will throw an exception. The plugin
-  expects to receive a relative path from the `yml` file folder.
+  attribute defined in the Avro file and use it, if a namespace is
+  not defined it will throw an exception. The plugin expects to receive
+  a relative path from the `yml` file folder.
 
 ```yaml
 order/created:

--- a/README.md
+++ b/README.md
@@ -368,8 +368,7 @@ order/createCommand:
       $ref: '#/components/messages/com.sngular.apigenerator.asyncapi.model.CreateOrder'
 ```
 
-- **Namespace from Avro**: If the user doesn't provide a package name, and the
-  entity is defined by an Avro Schema, the plugin will check for a `namespace`
+- **Namespace from Avro**: The plugin will check for a `namespace`
   attribute defined in the Avro file, and if there is, it will use it. The plugin
   expects to receive a relative path from the `yml` file folder.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ As commented above, they both could be used at the same time, setting a double
 <plugin>
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>5.3.5</version>
+  <version>5.3.6</version>
   <executions>
     <execution>
       <id>asyncapi</id>
@@ -114,7 +114,7 @@ Apply the plugin in the `build.gradle` file and invoke the task.
 ```groovy
 plugins {
   id "java"
-  id "com.sngular.scs-multiapi-gradle-plugin' version '5.3.5"
+  id "com.sngular.scs-multiapi-gradle-plugin' version '5.3.6"
 
   openapimodel {
 
@@ -153,7 +153,7 @@ which the plugin is designed.
 <plugin>
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>5.3.5</version>
+  <version>5.3.6</version>
   <executions>
     <execution>
       <phase>generate-sources</phase>
@@ -583,7 +583,7 @@ file. Here is an example of a basic configuration:
 <plugin>
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>5.3.5</version>
+  <version>5.3.6</version>
   <executions>
     <execution>
       <goals>

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ order/createCommand:
 ```
 
 - **Namespace from Avro**: The plugin will check for a `namespace`
-  attribute defined in the Avro file, and if there is, it will use it. The plugin
+  attribute defined in the Avro file and use it, if a namespace is not defined it will throw an exception. The plugin
   expects to receive a relative path from the `yml` file folder.
 
 ```yaml

--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>5.3.6</version>
+  <version>5.4.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>5.3.5</version>
+  <version>5.3.6</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.26</version>
+      <version>1.18.30</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGenerator.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGenerator.java
@@ -591,8 +591,7 @@ public class AsyncApiGenerator {
     final ObjectMapper mapper = new ObjectMapper();
     try {
       final JsonNode fileTree = mapper.readTree(avroFile);
-      final String fullNamespace = fileTree.get("namespace").asText() + PACKAGE_SEPARATOR + fileTree.get("name").asText();
-      namespace = processModelPackage(fullNamespace, modelPackage);
+      namespace = fileTree.get("namespace").asText() + PACKAGE_SEPARATOR + fileTree.get("name").asText();;//processModelPackage(fullNamespace, avroPackage);
     } catch (final IOException e) {
       throw new FileSystemException(e);
     }

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGenerator.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGenerator.java
@@ -28,12 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.sngular.api.generator.plugin.PluginConstants;
-import com.sngular.api.generator.plugin.asyncapi.exception.ChannelNameException;
-import com.sngular.api.generator.plugin.asyncapi.exception.DuplicateClassException;
-import com.sngular.api.generator.plugin.asyncapi.exception.DuplicatedOperationException;
-import com.sngular.api.generator.plugin.asyncapi.exception.ExternalRefComponentNotFoundException;
-import com.sngular.api.generator.plugin.asyncapi.exception.FileSystemException;
-import com.sngular.api.generator.plugin.asyncapi.exception.InvalidAsyncAPIException;
+import com.sngular.api.generator.plugin.asyncapi.exception.*;
 import com.sngular.api.generator.plugin.asyncapi.model.ProcessBindingsResult;
 import com.sngular.api.generator.plugin.asyncapi.model.ProcessBindingsResult.ProcessBindingsResultBuilder;
 import com.sngular.api.generator.plugin.asyncapi.model.ProcessMethodResult;
@@ -591,7 +586,11 @@ public class AsyncApiGenerator {
     final ObjectMapper mapper = new ObjectMapper();
     try {
       final JsonNode fileTree = mapper.readTree(avroFile);
-      namespace = fileTree.get("namespace").asText() + PACKAGE_SEPARATOR + fileTree.get("name").asText();;//processModelPackage(fullNamespace, avroPackage);
+      final JsonNode avroNamespace = fileTree.get("namespace");
+
+      if (avroNamespace == null) throw new InvalidAvroException(avroFilePath);
+
+      namespace = avroNamespace.asText() + PACKAGE_SEPARATOR + fileTree.get("name").asText();;//processModelPackage(fullNamespace, avroPackage);
     } catch (final IOException e) {
       throw new FileSystemException(e);
     }

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/exception/InvalidAvroException.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/exception/InvalidAvroException.java
@@ -1,0 +1,14 @@
+/*
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  * License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.sngular.api.generator.plugin.asyncapi.exception;
+
+public class InvalidAvroException extends RuntimeException {
+    private static final String ERROR_MESSAGE = "AsyncApi -> Avro schema at path %s lacks a namespace.";
+    public InvalidAvroException(final String enumName) {
+        super(String.format(ERROR_MESSAGE, enumName));
+    }
+}

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGeneratorFixtures.java
@@ -180,6 +180,23 @@ public class AsyncApiGeneratorFixtures {
           .build()
   );
 
+  final static List<SpecFile> TEST_ISSUE_INVALID_AVRO = List.of(
+          SpecFile
+                  .builder()
+                  .filePath("src/test/resources/asyncapigenerator/testIssueInvalidAvro/event-api.yml")
+                  .consumer(OperationParameterObject.builder()
+                          .ids("subscribeOperationExternalAvro")
+                          .apiPackage("com.sngular.scsplugin.issueAvro.model.event.consumer")
+                          .modelPackage("com.sngular.scsplugin.issueAvro.model.event")
+                          .build())
+                  .supplier(OperationParameterObject.builder()
+                          .ids("publishOperationExternalAvro")
+                          .apiPackage("com.sngular.scsplugin.issueAvro.model.event.producer")
+                          .modelPackage("com.sngular.scsplugin.issueAvro.model.event")
+                          .build())
+                  .build()
+  );
+
   final static List<SpecFile> TEST_FILE_GENERATION_STREAM_BRIDGE = List.of(
       SpecFile
           .builder()

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGeneratorFixtures.java
@@ -168,7 +168,7 @@ public class AsyncApiGeneratorFixtures {
           .builder()
           .filePath("src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/event-api.yml")
           .consumer(OperationParameterObject.builder()
-                                            .ids("subscribeOperationExternalAvro")
+                                            .ids("subscribeOperationExternalAvro,subscribeReceiptExternalAvro")
                                             .apiPackage("com.sngular.scsplugin.externalavro.model.event.consumer")
                                             .modelPackage("com.sngular.scsplugin.externalavro.model.event")
                                             .build())
@@ -743,6 +743,7 @@ public class AsyncApiGeneratorFixtures {
 
     final List<String> expectedConsumerFiles = List.of(
         ASSETS_PATH + "ISubscribeOperationExternalAvro.java",
+        ASSETS_PATH + "ISubscribeReceiptExternalAvro.java",
         ASSETS_PATH + "Subscriber.java"
     );
 

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGeneratorTest.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/AsyncApiGeneratorTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import com.sngular.api.generator.plugin.asyncapi.exception.InvalidAvroException;
 import com.sngular.api.generator.plugin.asyncapi.parameter.SpecFile;
 import com.sngular.api.generator.plugin.exception.InvalidAPIException;
 import org.assertj.core.api.Assertions;
@@ -89,6 +90,11 @@ class AsyncApiGeneratorTest {
   @Test
   void testExceptionForTestGenerationWithNoOperationConfiguration() {
     Assertions.assertThatThrownBy(() -> asyncApiGenerator.processFileSpec(AsyncApiGeneratorFixtures.TEST_FILE_GENERATION_NO_CONFIG)).isInstanceOf(InvalidAPIException.class);
+  }
+
+  @Test
+  void testExceptionForTestIssueInvalidAvro() {
+    Assertions.assertThatThrownBy(() -> asyncApiGenerator.processFileSpec(AsyncApiGeneratorFixtures.TEST_ISSUE_INVALID_AVRO)).isInstanceOf(InvalidAvroException.class);
   }
 
 }

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/IPublishOperation.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/IPublishOperation.java
@@ -1,6 +1,6 @@
 package com.sngular.scsplugin.externalavro.model.event.producer;
 
-import com.sngular.scsplugin.externalavro.model.event.Order;
+import com.sngular.disashop.business_model.model.event.Order;
 
 public interface IPublishOperationExternalAvro {
 

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/IPublishOperation.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/IPublishOperation.java
@@ -1,6 +1,6 @@
 package com.sngular.scsplugin.externalavro.model.event.producer;
 
-import com.sngular.disashop.business_model.model.event.Order;
+import com.sngular.testshop.business_model.model.event.Order;
 
 public interface IPublishOperationExternalAvro {
 

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/ISubscribeReceiptExternalAvro.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/ISubscribeReceiptExternalAvro.java
@@ -1,6 +1,6 @@
 package com.sngular.scsplugin.externalavro.model.event.consumer;
 
-import com.sngular.disashop.commons.Receipt;
+import com.sngular.testshop.commons.Receipt;
 
 public interface ISubscribeReceiptExternalAvro {
 

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/ISubscribeReceiptExternalAvro.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/ISubscribeReceiptExternalAvro.java
@@ -1,0 +1,8 @@
+package com.sngular.scsplugin.externalavro.model.event.consumer;
+
+import com.sngular.disashop.commons.Receipt;
+
+public interface ISubscribeReceiptExternalAvro {
+
+  void subscribeReceiptExternalAvro(final Receipt value);
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/Producer.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/Producer.java
@@ -4,7 +4,7 @@ import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.scsplugin.externalavro.model.event.Order;
+import com.sngular.disashop.business_model.model.event.Order;
 
 @Configuration
 public class Producer {

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/Producer.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/Producer.java
@@ -4,7 +4,7 @@ import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.disashop.business_model.model.event.Order;
+import com.sngular.testshop.business_model.model.event.Order;
 
 @Configuration
 public class Producer {

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/Subscriber.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/Subscriber.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.disashop.commons.Receipt;
+import com.sngular.testshop.commons.Receipt;
 import com.sngular.scsplugin.externalavro.model.event.CreateOrder;
 
 @Configuration

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/Subscriber.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/assets/Subscriber.java
@@ -4,15 +4,24 @@ import java.util.function.Consumer;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import com.sngular.disashop.commons.Receipt;
 import com.sngular.scsplugin.externalavro.model.event.CreateOrder;
 
 @Configuration
 public class Subscriber {
 
+  private final ISubscribeReceiptExternalAvro subscribeReceiptExternalAvro;
+
   private final ISubscribeOperationExternalAvro subscribeOperationExternalAvro;
 
-  protected Subscriber(final ISubscribeOperationExternalAvro subscribeOperationExternalAvro) {
+  protected Subscriber(final ISubscribeReceiptExternalAvro subscribeReceiptExternalAvro, final ISubscribeOperationExternalAvro subscribeOperationExternalAvro) {
+    this.subscribeReceiptExternalAvro = subscribeReceiptExternalAvro;
     this.subscribeOperationExternalAvro = subscribeOperationExternalAvro;
+  }
+
+  @Bean
+  public Consumer<Receipt> subscribeReceiptExternalAvro() {
+    return value -> subscribeReceiptExternalAvro.subscribeReceiptExternalAvro(value);
   }
 
   @Bean

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/avro/Order.avsc
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/avro/Order.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "Order",
-  "namespace": "com.sngular.disashop.business_model.model.event",
+  "namespace": "com.sngular.testshop.business_model.model.event",
   "fields": [
     {
       "name": "ref",

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/avro/Receipt.avsc
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/avro/Receipt.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "Receipt",
+  "namespace": "com.sngular.disashop.commons",
+  "fields": [
+    {
+      "name": "ref",
+      "type": "string"
+    }
+  ]
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/avro/Receipt.avsc
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/avro/Receipt.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "Receipt",
-  "namespace": "com.sngular.disashop.commons",
+  "namespace": "com.sngular.testshop.commons",
   "fields": [
     {
       "name": "ref",

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/event-api.yml
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testFileGenerationExternalAvro/event-api.yml
@@ -20,6 +20,12 @@ servers:
     protocol: kafka
     protocolVersion: 0.9.1
 channels:
+  order/receipt:
+    subscribe:
+      operationId: "subscribeReceiptExternalAvro"
+      message:
+        payload:
+          $ref: 'avro/Receipt.avsc'
   order/created:
     publish:
       operationId: "publishOperationExternalAvro"

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/IPublishOperation.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/IPublishOperation.java
@@ -1,6 +1,6 @@
 package com.sngular.scsplugin.issueAvro.model.event.producer;
 
-import com.sngular.disashop.business_model.model.event.Order;
+import com.sngular.testshop.business_model.model.event.Order;
 
 public interface IPublishOperationExternalAvro {
 

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/IPublishOperation.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/IPublishOperation.java
@@ -1,0 +1,8 @@
+package com.sngular.scsplugin.issueAvro.model.event.producer;
+
+import com.sngular.disashop.business_model.model.event.Order;
+
+public interface IPublishOperationExternalAvro {
+
+  Order publishOperationExternalAvro();
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/ISubscribeOperationExternalAvro.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/ISubscribeOperationExternalAvro.java
@@ -1,0 +1,8 @@
+package com.sngular.scsplugin.issueAvro.model.event.consumer;
+
+import com.sngular.scsplugin.issueAvro.model.event.CreateOrder;
+
+public interface ISubscribeOperationExternalAvro {
+
+  void subscribeOperationExternalAvro(final CreateOrder value);
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/ModelClassException.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package com.sngular.scsplugin.issueAvro.model.event.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/Producer.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/Producer.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.issueAvro.model.event.producer;
+
+import java.util.function.Supplier;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.sngular.disashop.business_model.model.event.Order;
+
+@Configuration
+public class Producer {
+
+  private final IPublishOperationExternalAvro publishOperationExternalAvro;
+
+  protected Producer(final IPublishOperationExternalAvro publishOperationExternalAvro) {
+    this.publishOperationExternalAvro = publishOperationExternalAvro;
+  }
+
+  @Bean
+  public Supplier<Order> publishOperationExternalAvro() {
+    return () -> publishOperationExternalAvro.publishOperationExternalAvro();
+  }
+
+
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/Producer.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/Producer.java
@@ -4,7 +4,7 @@ import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.sngular.disashop.business_model.model.event.Order;
+import com.sngular.testshop.business_model.model.event.Order;
 
 @Configuration
 public class Producer {

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/Subscriber.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/assets/Subscriber.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.issueAvro.model.event.consumer;
+
+import java.util.function.Consumer;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.sngular.scsplugin.issueAvro.model.event.CreateOrder;
+
+@Configuration
+public class Subscriber {
+
+  private final ISubscribeOperationExternalAvro subscribeOperationExternalAvro;
+
+  protected Subscriber(final ISubscribeOperationExternalAvro subscribeOperationExternalAvro) {
+    this.subscribeOperationExternalAvro = subscribeOperationExternalAvro;
+  }
+
+  @Bean
+  public Consumer<CreateOrder> subscribeOperationExternalAvro() {
+    return value -> subscribeOperationExternalAvro.subscribeOperationExternalAvro(value);
+  }
+
+
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/avro/Order.avsc
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/avro/Order.avsc
@@ -1,0 +1,105 @@
+{
+  "type": "record",
+  "name": "Order",
+  "fields": [
+    {
+      "name": "ref",
+      "type": "string"
+    },
+    {
+      "name": "clientRef",
+      "type": "string"
+    },
+    {
+      "name": "amount",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 10,
+        "scale": 2
+      }
+    },
+    {
+      "name": "lines",
+      "type": {
+        "type": "array",
+        "items": {
+          "name": "OrderLine",
+          "type": "record",
+          "fields": [
+            {
+              "name": "ref",
+              "type": "string"
+            },
+            {
+              "name": "products",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "OrderProduct",
+                  "fields": [
+                    {
+                      "name": "ref",
+                      "type": "string"
+                    },
+                    {
+                      "name": "productRef",
+                      "type": "string"
+                    },
+                    {
+                      "name": "price",
+                      "type": {
+                        "type": "bytes",
+                        "logicalType": "decimal",
+                        "precision": 10,
+                        "scale": 2
+                      }
+                    },
+                    {
+                      "name": "quantity",
+                      "type": {
+                        "type": "bytes",
+                        "logicalType": "decimal",
+                        "precision": 10,
+                        "scale": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "promotions",
+      "type": {
+        "type": "array",
+        "items": {
+          "name": "Promotion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "ref",
+              "type": "string"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "discount",
+              "type": "boolean"
+            },
+            {
+              "name": "amount",
+              "type": "double"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/event-api.yml
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/testIssueInvalidAvro/event-api.yml
@@ -1,0 +1,101 @@
+asyncapi: 2.3.0
+info:
+  title: Order Service
+  version: 1.0.0
+  description: Order management Service
+servers:
+  development:
+    url: development.gigantic-server.com
+    description: Development server
+    protocol: kafka
+    protocolVersion: 0.9.1
+  staging:
+    url: staging.gigantic-server.com
+    description: Staging server
+    protocol: kafka
+    protocolVersion: 0.9.1
+  production:
+    url: api.gigantic-server.com
+    description: Production server
+    protocol: kafka
+    protocolVersion: 0.9.1
+channels:
+  order/created:
+    publish:
+      operationId: "publishOperationExternalAvro"
+      message:
+        payload:
+          $ref: 'avro/Order.avsc'
+  order/createCommand:
+    subscribe:
+      operationId: "subscribeOperationExternalAvro"
+      message:
+        $ref: '#/components/messages/CreateOrder'
+components:
+  messages:
+    OrderCreated:
+      payload:
+        $ref: '#/components/schemas/Order'
+    CreateOrder:
+      payload:
+        type: object
+        properties:
+          order:
+            $ref: '#/components/schemas/Order'
+          waiter:
+            $ref: '#/components/schemas/Waiter'
+  schemas:
+    Waiter:
+      type: object
+      properties:
+        ref:
+          type: string
+        timestamp:
+          type: string
+          format: 'dd/mm/yyyy hh:MM:sss'
+        table:
+          type: string
+    Order:
+      type: object
+      properties:
+        ref:
+          type: string
+        clientRef:
+          type: string
+        amount:
+          type: string
+          format: decimal
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderLine'
+    OrderLine:
+      type: object
+      required:
+        - ref
+        - products
+      properties:
+        ref:
+          type: string
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderProduct'
+    OrderProduct:
+      type: object
+      required:
+        - ref
+        - productRef
+        - price
+        - quantity
+      properties:
+        ref:
+          type: string
+        productRef:
+          type: string
+        price:
+          type: string
+          format: decimal
+        quantity:
+          type: string
+          format: decimal

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '5.3.6'
+version = '5.4.0'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -30,7 +30,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:5.3.6'
+  implementation 'com.sngular:multiapi-engine:5.4.0'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
 }
@@ -98,7 +98,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:5.3.6'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:5.4.0'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '5.3.5'
+version = '5.3.6'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -30,7 +30,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:5.3.5'
+  implementation 'com.sngular:multiapi-engine:5.3.6'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
 }
@@ -98,7 +98,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:5.3.5'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:5.3.6'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -196,6 +196,17 @@
       </roles>
       <timezone>Europe/Madrid</timezone>
     </developer>
+    <developer>
+      <id>MarcosFreireSngular</id>
+      <name>Marcos Freire Patiño</name>
+      <email>marcos.freire@sngular.com</email>
+      <organization>Sngular</organization>
+      <organizationUrl>https://www.sngular.com</organizationUrl>
+      <roles>
+        <role>Software Developer - Trainee</role>
+      </roles>
+      <timezone>Europe/Madrid</timezone>
+    </developer>
   </developers>
 
   <scm>

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>5.3.5</version>
+  <version>5.3.6</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -237,13 +237,13 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.26</version>
+      <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>5.3.5</version>
+      <version>5.3.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>5.3.6</version>
+  <version>5.4.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -243,7 +243,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>5.3.6</version>
+      <version>5.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Changes allow for MultiApi to reference correctly the package of autogenerated Avro classes by taking into account the namespace atribute contained in the file schemas instead of the configured MultiApi model package present in the project pom.xml.