### PR TITLE
Fix #372: resolve external Path Item $ref in OpenAPI generator

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.3.2</version>
+  <version>6.3.3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/OpenApiGenerator.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/OpenApiGenerator.java
@@ -98,6 +98,7 @@ public class OpenApiGenerator {
   private void processFile(final SpecFile specFile) {
 
     final JsonNode openAPI = OpenApiUtil.getPojoFromSpecFile(baseDir, specFile);
+    OpenApiUtil.solvePathRefs(openAPI, baseDir.resolve(specFile.getFilePath()).getParent().toUri());
     final String clientPackage = specFile.getClientPackage();
 
     if (specFile.isCallMode()) {

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/utils/OpenApiUtil.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/utils/OpenApiUtil.java
@@ -6,6 +6,7 @@
 
 package com.sngular.api.generator.plugin.openapi.utils;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -89,6 +90,33 @@ public class OpenApiUtil {
   public static JsonNode getPojoFromSpecFile(final Path baseDir, final SpecFile specFile) {
 
     return SchemaUtil.getPojoFromRef(baseDir.toUri(), specFile.getFilePath());
+  }
+
+  /**
+   * Dereferences Path Item Objects that are declared as a {@code $ref} to another file (modular
+   * contracts). These references are otherwise never resolved, so the affected paths silently
+   * disappear from generation. The referenced Path Item is resolved and set in place, so every
+   * downstream consumer (API grouping, path mapping and model extraction) sees the real operations.
+   *
+   * @param openApi      the parsed root contract; its {@code paths} node is mutated in place.
+   * @param rootFilePath base URI used to resolve relative external references.
+   */
+  public static void solvePathRefs(final JsonNode openApi, final URI rootFilePath) {
+    final JsonNode pathsNode = openApi.get(PATHS);
+    if (pathsNode instanceof ObjectNode) {
+      final ObjectNode paths = (ObjectNode) pathsNode;
+      final Map<String, JsonNode> resolvedItems = new HashMap<>();
+      paths.fields().forEachRemaining(pathItem -> {
+        final JsonNode pathValue = pathItem.getValue();
+        if (ApiTool.hasRef(pathValue)) {
+          final JsonNode resolved = SchemaUtil.solveRef(ApiTool.getRefValue(pathValue), new HashMap<>(), rootFilePath);
+          if (Objects.nonNull(resolved)) {
+            resolvedItems.put(pathItem.getKey(), resolved);
+          }
+        }
+      });
+      resolvedItems.forEach(paths::set);
+    }
   }
 
   public static Map<String, JsonNode> processPaths(final JsonNode openApi, final Map<String, JsonNode> schemaMap, SpecFile specFile) {

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -147,6 +147,13 @@ public final class OpenApiGeneratorFixtures {
 					.clientPackage("com.sngular.multifileplugin.externalref.client").modelNamePrefix("Api")
 					.modelNameSuffix("DTO").build());
 
+	static final List<SpecFile> TEST_EXTERNAL_PATH_ITEM_REF_GENERATION = List
+			.of(SpecFile.builder().filePath("openapigenerator/testExternalPathItemRefsGeneration/api-test.yml")
+					.apiPackage("com.sngular.multifileplugin.externalpathitemref")
+					.modelPackage("com.sngular.multifileplugin.externalpathitemref.model")
+					.clientPackage("com.sngular.multifileplugin.externalpathitemref.client")
+					.modelNameSuffix("DTO").build());
+
 	static final List<SpecFile> TEST_ANY_OF_IN_RESPONSE = List
 			.of(SpecFile.builder().filePath("openapigenerator/testAnyOfInResponse/api-test.yml")
 					.apiPackage("com.sngular.multifileplugin.testanyofinresponse")
@@ -761,6 +768,24 @@ public final class OpenApiGeneratorFixtures {
 
 		return path -> commonTest(path, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API,
 				DEFAULT_MODEL_API, expectedExceptionFiles, DEFAULT_EXCEPTION_API);
+	}
+
+	static Function<Path, Boolean> validateExternalPathItemRefGeneration() {
+
+		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/externalpathitemref";
+
+		final String DEFAULT_MODEL_API = "generated/com/sngular/multifileplugin/externalpathitemref/model";
+
+		final String COMMON_PATH = "openapigenerator/testExternalPathItemRefsGeneration/";
+
+		final String ASSETS_PATH = COMMON_PATH + "assets/";
+
+		final List<String> expectedTestApiFile = List.of(ASSETS_PATH + "DashboardApi.java");
+
+		final List<String> expectedTestApiModelFiles = List.of(ASSETS_PATH + "DashboardDTO.java");
+
+		return path -> commonTest(path, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API,
+				DEFAULT_MODEL_API, Collections.emptyList(), null);
 	}
 
 	static Function<Path, Boolean> validateAnyOfInResponse() {

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
@@ -83,6 +83,8 @@ class OpenApiGeneratorTest {
             OpenApiGeneratorFixtures.validateEnumsLombokGeneration()),
         Arguments.of("testExternalRefsGeneration", OpenApiGeneratorFixtures.TEST_EXTERNAL_REF_GENERATION,
             OpenApiGeneratorFixtures.validateExternalRefGeneration()),
+        Arguments.of("testExternalPathItemRefsGeneration", OpenApiGeneratorFixtures.TEST_EXTERNAL_PATH_ITEM_REF_GENERATION,
+            OpenApiGeneratorFixtures.validateExternalPathItemRefGeneration()),
         Arguments.of("testAnyOfInResponse", OpenApiGeneratorFixtures.TEST_ANY_OF_IN_RESPONSE,
             OpenApiGeneratorFixtures.validateAnyOfInResponse()),
         Arguments.of("testOneOfInResponse", OpenApiGeneratorFixtures.TEST_ONE_OF_IN_RESPONSE,

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalPathItemRefsGeneration/api-test.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalPathItemRefsGeneration/api-test.yml
@@ -1,0 +1,32 @@
+---
+# Reproduction for: external Path Item $ref produces 0 files silently (issue #372).
+# The `paths` entries are $ref'd out to a separate file (modular contract), exactly
+# like a Redocly/Swagger split contract. openapi 3.1.0 to match the real-world case,
+# but no 3.1-only schema constructs are used so the ONLY blocker under test is the
+# unresolved external Path Item $ref. Schemas are referenced with the already-supported
+# internal component ref style (#/components/schemas/...).
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Dashboard API (modular contract)
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:8080/v1
+tags:
+  - name: dashboard
+paths:
+  /dashboard:
+    $ref: "./paths/dashboard.yml"
+components:
+  schemas:
+    Dashboard:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        widgetCount:
+          type: integer
+          format: int32

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalPathItemRefsGeneration/assets/DashboardApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalPathItemRefsGeneration/assets/DashboardApi.java
@@ -1,0 +1,46 @@
+package com.sngular.multifileplugin.externalpathitemref;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import com.sngular.multifileplugin.externalpathitemref.model.DashboardDTO;
+
+public interface DashboardApi {
+
+  /**
+   * GET /dashboard: Get the dashboard
+   * @return  The requested dashboard; (status code 200)
+   */
+
+  @Operation(
+    operationId = "getDashboard",
+    summary = "Get the dashboard",
+    tags = {"dashboard"},
+    responses = {
+      @ApiResponse(responseCode = "200", description = "The requested dashboard", content = @Content(mediaType = "application/json", schema = @Schema(implementation = DashboardDTO.class)))
+    }
+  )
+  @RequestMapping(
+    method = RequestMethod.GET,
+    value = "/dashboard",
+    produces = {"application/json"}
+  )
+
+  default ResponseEntity<DashboardDTO> getDashboard() {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalPathItemRefsGeneration/assets/DashboardDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalPathItemRefsGeneration/assets/DashboardDTO.java
@@ -1,0 +1,112 @@
+package com.sngular.multifileplugin.externalpathitemref.model;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonDeserialize(builder = DashboardDTO.DashboardDTOBuilder.class)
+public class DashboardDTO {
+
+  @JsonProperty(value ="id")
+  private String id;
+  @JsonProperty(value ="title")
+  private String title;
+  @JsonProperty(value ="widgetCount")
+  private Integer widgetCount;
+
+  private DashboardDTO(DashboardDTOBuilder builder) {
+    this.id = builder.id;
+    this.title = builder.title;
+    this.widgetCount = builder.widgetCount;
+
+  }
+
+  public static DashboardDTO.DashboardDTOBuilder builder() {
+    return new DashboardDTO.DashboardDTOBuilder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class DashboardDTOBuilder {
+
+    private String id;
+    private String title;
+    private Integer widgetCount;
+
+    public DashboardDTO.DashboardDTOBuilder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public DashboardDTO.DashboardDTOBuilder title(String title) {
+      this.title = title;
+      return this;
+    }
+
+    public DashboardDTO.DashboardDTOBuilder widgetCount(Integer widgetCount) {
+      this.widgetCount = widgetCount;
+      return this;
+    }
+
+    public DashboardDTO build() {
+      DashboardDTO dashboardDTO = new DashboardDTO(this);
+      return dashboardDTO;
+    }
+  }
+
+  @Schema(name = "id", required = false)
+  public String getId() {
+    return id;
+  }
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  @Schema(name = "title", required = false)
+  public String getTitle() {
+    return title;
+  }
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  @Schema(name = "widgetCount", required = false)
+  public Integer getWidgetCount() {
+    return widgetCount;
+  }
+  public void setWidgetCount(Integer widgetCount) {
+    this.widgetCount = widgetCount;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DashboardDTO dashboardDTO = (DashboardDTO) o;
+    return Objects.equals(this.id, dashboardDTO.id) && Objects.equals(this.title, dashboardDTO.title) && Objects.equals(this.widgetCount, dashboardDTO.widgetCount);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, title, widgetCount);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("DashboardDTO{");
+    sb.append(" id:").append(id).append(",");
+    sb.append(" title:").append(title).append(",");
+    sb.append(" widgetCount:").append(widgetCount);
+    sb.append("}");
+    return sb.toString();
+  }
+
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalPathItemRefsGeneration/paths/dashboard.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalPathItemRefsGeneration/paths/dashboard.yml
@@ -1,0 +1,18 @@
+---
+# A standalone Path Item Object, referenced from the root contract via
+# `paths: /dashboard: { $ref: './paths/dashboard.yml' }`.
+# Note: the only top-level keys here are HTTP verbs (`get`) - there is NO
+# `$ref` verb, which is why `OpenApiUtil.mapApiGroups` filtering for REST
+# verbs finds nothing when it sees the *reference* node in the root file.
+get:
+  summary: Get the dashboard
+  operationId: getDashboard
+  tags:
+    - dashboard
+  responses:
+    '200':
+      description: The requested dashboard
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Dashboard"

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.3.2'
+version = '6.3.3'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.3.2'
+  implementation 'com.sngular:multiapi-engine:6.3.3'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.3.2</version>
+    <version>6.3.3</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.3.2</version>
+      <version>6.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## What

Fixes #372 — modular OpenAPI contracts that `$ref` their paths out to separate files
(`paths: { /x: { $ref: './paths/x.yml' } }`) completed with **BUILD SUCCESS but generated
zero API files and no models, silently**.

## Root cause

`OpenApiUtil.mapApiGroups` builds the API groups by iterating each path item and filtering
for REST-verb keys (`get`/`post`/`put`/`patch`/`delete`). A Path Item that is a
`{ "$ref": "./paths/x.yml" }` node has no verb keys, so nothing was ever added to the group
map and the generation loop never ran. Nothing anywhere dereferenced a **Path Item** `$ref`
(`SchemaUtil.solveRef` was only invoked from schema/model resolution). It is not a 3.1-specific
bug — it reproduces on 3.0.x too.

## Change

- Add `OpenApiUtil.solvePathRefs(openApi, rootFilePath)` which walks the top-level `paths` and,
  for any Path Item declared as a `$ref`, resolves the referenced node via `SchemaUtil.solveRef`
  and substitutes it in place. Every downstream consumer (API grouping, path mapping, model
  extraction) then sees the real operations. Non-ref path items are untouched — no behavior
  change for existing specs.
- Invoke it once, right after parsing, in `OpenApiGenerator.processFile`, resolving relative
  refs against the spec file's directory (consistent with existing schema-ref resolution).

## Tests

- New fixture `testExternalPathItemRefsGeneration/` (modular `3.1.0` contract with the path split
  into `paths/dashboard.yml`), golden assets `DashboardApi.java` + `DashboardDTO.java` generated
  by the fixed code, wired into `OpenApiGeneratorTest` / `OpenApiGeneratorFixtures`.
- `OpenApiGeneratorTest`: **Tests run: 45, Failures: 0, Errors: 0**. Before the fix this fixture
  produced 0 files.

## Versioning

Bumps `6.3.2` → `6.3.3` across `multiapi-engine`, `scs-multiapi-maven-plugin` (own version +
engine dependency) and `scs-multiapi-gradle-plugin` (own version + engine dependency).

## Out of scope / follow-up

While validating this fix, a **separate, pre-existing limitation** surfaced: an external
**schema-file** `$ref` *without* a `#/components/...` fragment (the whole file is the schema) is
not resolved into a model. Tracked in #373. The already-supported external form is a fragment ref
into a components file (e.g. `components.yml#/components/schemas/Name`), as in the existing
`testExternalRefsGeneration` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
