### PR TITLE
Release 6.5.3: Gradle JDK 21 fix + OpenAPI 3.1 refinements (enum metadata, deprecated)

### DIFF
--- a/.github/workflows/gradle-portal-push.yml
+++ b/.github/workflows/gradle-portal-push.yml
@@ -50,10 +50,10 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v2
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "adopt"
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.5.1</version>
+  <version>6.5.2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.5.2</version>
+  <version>6.5.3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/model/SchemaFieldObject.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/model/SchemaFieldObject.java
@@ -32,4 +32,6 @@ public class SchemaFieldObject {
   private String description;
 
   private String example;
+
+  private boolean deprecated;
 }

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ApiTool.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ApiTool.java
@@ -484,6 +484,10 @@ public final class ApiTool {
     return getNodeAsString(schema, "description");
   }
 
+  public static boolean isDeprecated(final JsonNode schema) {
+    return getNodeAsBoolean(schema, "deprecated");
+  }
+
   public static String getExample(final JsonNode schema) {
     // OpenAPI 3.0 uses a single `example`; OpenAPI 3.1 / JSON Schema 2020-12 use an
     // `examples` array. Prefer `example`, otherwise take the first `examples` entry.

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ModelBuilder.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ModelBuilder.java
@@ -872,6 +872,10 @@ public final class ModelBuilder {
       throw new BadDefinedEnumException(name);
     }
     field.setEnumValues(enumValuesMap);
+    // Enum fields bypass processObjectProperty's applyMetadata, so carry the schema's
+    // description/example here too for consistent @Schema annotations.
+    field.setDescription(ApiTool.getDescription(value));
+    field.setExample(ApiTool.getExample(value));
     return field;
   }
 

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ModelBuilder.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ModelBuilder.java
@@ -346,7 +346,8 @@ public final class ModelBuilder {
   private static void applyMetadata(final List<SchemaFieldObject> fields, final String fieldName, final JsonNode fieldBody) {
     final String description = ApiTool.getDescription(fieldBody);
     final String example = ApiTool.getExample(fieldBody);
-    if (Objects.isNull(description) && Objects.isNull(example)) {
+    final boolean deprecated = ApiTool.isDeprecated(fieldBody);
+    if (Objects.isNull(description) && Objects.isNull(example) && !deprecated) {
       return;
     }
     for (final var field : fields) {
@@ -356,6 +357,9 @@ public final class ModelBuilder {
         }
         if (Objects.nonNull(example)) {
           field.setExample(example);
+        }
+        if (deprecated) {
+          field.setDeprecated(true);
         }
       }
     }
@@ -873,9 +877,10 @@ public final class ModelBuilder {
     }
     field.setEnumValues(enumValuesMap);
     // Enum fields bypass processObjectProperty's applyMetadata, so carry the schema's
-    // description/example here too for consistent @Schema annotations.
+    // description/example/deprecated here too for consistent @Schema annotations.
     field.setDescription(ApiTool.getDescription(value));
     field.setExample(ApiTool.getExample(value));
+    field.setDeprecated(ApiTool.isDeprecated(value));
     return field;
   }
 

--- a/multiapi-engine/src/main/resources/templates/model/templateSchema.ftlh
+++ b/multiapi-engine/src/main/resources/templates/model/templateSchema.ftlh
@@ -340,7 +340,7 @@ public class ${schema.className} {
   }
 
 <#list schema.fieldObjectList as field>
-  @Schema(name = "${field.baseName?uncap_first}", required = <#if field.required?has_content && field.required == true>true<#else>false</#if><#if field.description?has_content>, description = "${field.description?j_string}"</#if><#if field.example?has_content>, example = "${field.example?j_string}"</#if>)
+  @Schema(name = "${field.baseName?uncap_first}", required = <#if field.required?has_content && field.required == true>true<#else>false</#if><#if field.description?has_content>, description = "${field.description?j_string}"</#if><#if field.example?has_content>, example = "${field.example?j_string}"</#if><#if field.deprecated>, deprecated = true</#if>)
   <#if field.dataType.baseType == "array">
   public ${field.dataType} get${field.baseName?cap_first}() {
     return ${calculateSafeName (field.baseName, ";")}

--- a/multiapi-engine/src/test/resources/openapigenerator/testOpenApi31Completeness/api-test.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testOpenApi31Completeness/api-test.yml
@@ -42,6 +42,9 @@ components:
           description: The unique gadget identifier
           examples:
             - "gadget-001"
+        legacyId:
+          type: string
+          deprecated: true
         serial:
           type: ["string", "null"]
           example: "SN-12345"

--- a/multiapi-engine/src/test/resources/openapigenerator/testOpenApi31Completeness/api-test.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testOpenApi31Completeness/api-test.yml
@@ -58,6 +58,12 @@ components:
           patternProperties:
             "^x-":
               type: string
+        status:
+          type: string
+          description: Lifecycle status of the gadget
+          enum:
+            - ACTIVE
+            - RETIRED
         nothing:
           type: "null"
         owner:

--- a/multiapi-engine/src/test/resources/openapigenerator/testOpenApi31Completeness/assets/GadgetDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testOpenApi31Completeness/assets/GadgetDTO.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
@@ -16,6 +17,28 @@ import java.util.HashMap;
 @JsonDeserialize(builder = GadgetDTO.GadgetDTOBuilder.class)
 public class GadgetDTO {
 
+  @JsonProperty(value ="status")
+  private Status status;
+  public enum Status {
+    ACTIVE("ACTIVE"),
+    RETIRED("RETIRED");
+
+    private String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+  }
   @JsonProperty(value ="payload")
   private MultipartFile payload;
   @JsonProperty(value ="nothing")
@@ -32,6 +55,7 @@ public class GadgetDTO {
   private String serial;
 
   private GadgetDTO(GadgetDTOBuilder builder) {
+    this.status = builder.status;
     this.payload = builder.payload;
     this.nothing = builder.nothing;
     this.id = builder.id;
@@ -49,6 +73,7 @@ public class GadgetDTO {
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class GadgetDTOBuilder {
 
+    private Status status;
     private MultipartFile payload;
     private Object nothing;
     private String id;
@@ -56,6 +81,11 @@ public class GadgetDTO {
     private List<BigDecimal> coords = new ArrayList<BigDecimal>();
     private PersonDTO owner;
     private String serial;
+
+    public GadgetDTO.GadgetDTOBuilder status(Status status) {
+      this.status = status;
+      return this;
+    }
 
     public GadgetDTO.GadgetDTOBuilder payload(MultipartFile payload) {
       this.payload = payload;
@@ -110,6 +140,14 @@ public class GadgetDTO {
       GadgetDTO gadgetDTO = new GadgetDTO(this);
       return gadgetDTO;
     }
+  }
+
+  @Schema(name = "status", required = false, description = "Lifecycle status of the gadget")
+  public Status getStatus() {
+    return status;
+  }
+  public void setStatus(Status status) {
+    this.status = status;
   }
 
   @Schema(name = "payload", required = false)
@@ -177,18 +215,19 @@ public class GadgetDTO {
       return false;
     }
     GadgetDTO gadgetDTO = (GadgetDTO) o;
-    return Objects.equals(this.payload, gadgetDTO.payload) && Objects.equals(this.nothing, gadgetDTO.nothing) && Objects.equals(this.id, gadgetDTO.id) && Objects.equals(this.metadata, gadgetDTO.metadata) && Objects.equals(this.coords, gadgetDTO.coords) && Objects.equals(this.owner, gadgetDTO.owner) && Objects.equals(this.serial, gadgetDTO.serial);
+    return Objects.equals(this.status, gadgetDTO.status) && Objects.equals(this.payload, gadgetDTO.payload) && Objects.equals(this.nothing, gadgetDTO.nothing) && Objects.equals(this.id, gadgetDTO.id) && Objects.equals(this.metadata, gadgetDTO.metadata) && Objects.equals(this.coords, gadgetDTO.coords) && Objects.equals(this.owner, gadgetDTO.owner) && Objects.equals(this.serial, gadgetDTO.serial);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(payload, nothing, id, metadata, coords, owner, serial);
+    return Objects.hash(status, payload, nothing, id, metadata, coords, owner, serial);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("GadgetDTO{");
+    sb.append(" status:").append(status).append(",");
     sb.append(" payload:").append(payload).append(",");
     sb.append(" nothing:").append(nothing).append(",");
     sb.append(" id:").append(id).append(",");

--- a/multiapi-engine/src/test/resources/openapigenerator/testOpenApi31Completeness/assets/GadgetDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testOpenApi31Completeness/assets/GadgetDTO.java
@@ -39,6 +39,8 @@ public class GadgetDTO {
       return String.valueOf(value);
     }
   }
+  @JsonProperty(value ="legacyId")
+  private String legacyId;
   @JsonProperty(value ="payload")
   private MultipartFile payload;
   @JsonProperty(value ="nothing")
@@ -56,6 +58,7 @@ public class GadgetDTO {
 
   private GadgetDTO(GadgetDTOBuilder builder) {
     this.status = builder.status;
+    this.legacyId = builder.legacyId;
     this.payload = builder.payload;
     this.nothing = builder.nothing;
     this.id = builder.id;
@@ -74,6 +77,7 @@ public class GadgetDTO {
   public static class GadgetDTOBuilder {
 
     private Status status;
+    private String legacyId;
     private MultipartFile payload;
     private Object nothing;
     private String id;
@@ -84,6 +88,11 @@ public class GadgetDTO {
 
     public GadgetDTO.GadgetDTOBuilder status(Status status) {
       this.status = status;
+      return this;
+    }
+
+    public GadgetDTO.GadgetDTOBuilder legacyId(String legacyId) {
+      this.legacyId = legacyId;
       return this;
     }
 
@@ -148,6 +157,14 @@ public class GadgetDTO {
   }
   public void setStatus(Status status) {
     this.status = status;
+  }
+
+  @Schema(name = "legacyId", required = false, deprecated = true)
+  public String getLegacyId() {
+    return legacyId;
+  }
+  public void setLegacyId(String legacyId) {
+    this.legacyId = legacyId;
   }
 
   @Schema(name = "payload", required = false)
@@ -215,12 +232,12 @@ public class GadgetDTO {
       return false;
     }
     GadgetDTO gadgetDTO = (GadgetDTO) o;
-    return Objects.equals(this.status, gadgetDTO.status) && Objects.equals(this.payload, gadgetDTO.payload) && Objects.equals(this.nothing, gadgetDTO.nothing) && Objects.equals(this.id, gadgetDTO.id) && Objects.equals(this.metadata, gadgetDTO.metadata) && Objects.equals(this.coords, gadgetDTO.coords) && Objects.equals(this.owner, gadgetDTO.owner) && Objects.equals(this.serial, gadgetDTO.serial);
+    return Objects.equals(this.status, gadgetDTO.status) && Objects.equals(this.legacyId, gadgetDTO.legacyId) && Objects.equals(this.payload, gadgetDTO.payload) && Objects.equals(this.nothing, gadgetDTO.nothing) && Objects.equals(this.id, gadgetDTO.id) && Objects.equals(this.metadata, gadgetDTO.metadata) && Objects.equals(this.coords, gadgetDTO.coords) && Objects.equals(this.owner, gadgetDTO.owner) && Objects.equals(this.serial, gadgetDTO.serial);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, payload, nothing, id, metadata, coords, owner, serial);
+    return Objects.hash(status, legacyId, payload, nothing, id, metadata, coords, owner, serial);
   }
 
   @Override
@@ -228,6 +245,7 @@ public class GadgetDTO {
     StringBuilder sb = new StringBuilder();
     sb.append("GadgetDTO{");
     sb.append(" status:").append(status).append(",");
+    sb.append(" legacyId:").append(legacyId).append(",");
     sb.append(" payload:").append(payload).append(",");
     sb.append(" nothing:").append(nothing).append(",");
     sb.append(" id:").append(id).append(",");

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.5.2'
+version = '6.5.3'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.5.2'
+  implementation 'com.sngular:multiapi-engine:6.5.3'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.5.2'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.5.3'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.5.1'
+version = '6.5.2'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.5.1'
+  implementation 'com.sngular:multiapi-engine:6.5.2'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.5.1'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.5.2'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.5.2</version>
+    <version>6.5.3</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.5.2</version>
+      <version>6.5.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.5.1</version>
+      <version>6.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Follow-up to #383 (merged as 6.5.1 with the Maven Central publish fix). #383's squash merge captured only its first commit, so **the Gradle release CI fix did not land** — this PR restores it and adds two more OpenAPI 3.1 refinements. Cuts **6.5.3**.

## Release-blocking fix (missing from main)
- **Gradle release CI:** `gradle-portal-push` workflow set up **JDK 17** but runs `mvn install` on the engine (compiled with `release 21`) → fails with "release version 21 not supported". Bumped to **JDK 21**, matching the Maven workflows.

## OpenAPI 3.1 refinements
- `description`/`example`/`examples` now propagate to **enum** fields (they bypassed the metadata step).
- **`deprecated: true`** on a property or enum is emitted as `@Schema(deprecated = true)` (was ignored).

## Version
`6.5.1` → `6.5.3` (engine, Maven plugin, Gradle plugin). Central versions are immutable, so a fresh number is required to re-publish.

## Verification
Full `multiapi-engine` suite: **110/110** (`mvn clean test`).

> Note: main already has the Maven Central publish fix (`central-publishing-maven-plugin` 0.11.0) and the `prefixItems` refinement from #383; those are not repeated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)