### PR TITLE
Map array of binary strings to List<MultipartFile>

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.6.0</version>
+  <version>6.6.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ModelBuilder.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ModelBuilder.java
@@ -493,10 +493,11 @@ public final class ModelBuilder {
                                      .dataType(SchemaFieldObjectType.fromTypeList(TypeConstants.ARRAY, MapperUtil.getPojoName(fieldName, specFile)))
                                      .build());
       } else {
+        final String itemType = ApiTool.isBinary(items) ? TypeConstants.MULTIPART_FILE : MapperUtil.getSimpleType(items, specFile);
         final SchemaFieldObject field = SchemaFieldObject
                                             .builder()
                                             .baseName(fieldName)
-                                            .dataType(SchemaFieldObjectType.fromTypeList(TypeConstants.ARRAY, MapperUtil.getSimpleType(items, specFile)))
+                                            .dataType(SchemaFieldObjectType.fromTypeList(TypeConstants.ARRAY, itemType))
                                             .build();
         fieldObjectArrayList.add(field);
         addPropertiesToFieldObject(field, schema);

--- a/multiapi-engine/src/test/resources/openapigenerator/testSimpleBuild/api-rest.yaml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testSimpleBuild/api-rest.yaml
@@ -522,6 +522,11 @@ components:
           type: string
           format: binary
           example: invoice01234.pdf
+        attachments:
+          type: array
+          items:
+            type: string
+            format: binary
         description:
           type: string
           example: Invoice for the sale 01234

--- a/multiapi-engine/src/test/resources/openapigenerator/testSimpleBuild/assets/model/DocumentDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testSimpleBuild/assets/model/DocumentDTO.java
@@ -2,7 +2,10 @@ package com.sngular.multifileplugin.testsimplebuild.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+import java.util.ArrayList;
 import lombok.Builder;
+import lombok.Singular;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
@@ -12,14 +15,19 @@ public class DocumentDTO {
   @JsonProperty(value ="description")
   private String description;
 
+  @JsonProperty(value ="attachments")
+  @Singular("attachment")
+  private List<MultipartFile> attachments;
+
   @JsonProperty(value ="document")
   private MultipartFile document;
 
 
   @Builder
   @Jacksonized
-  private DocumentDTO(String description, MultipartFile document) {
+  private DocumentDTO(String description, List<MultipartFile> attachments, MultipartFile document) {
     this.description = description;
+    this.attachments = attachments;
     this.document = document;
 
   }

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.6.0'
+version = '6.6.1'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.6.0'
+  implementation 'com.sngular:multiapi-engine:6.6.1'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.0'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.1'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.6.0</version>
+    <version>6.6.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.6.0</version>
+      <version>6.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## What

Fixes the mapping of **arrays of binary strings** (multiple file upload) in the OpenAPI generator. They were generated as `List<String>` instead of `List<MultipartFile>`.

Closes #386.

## Why

`ModelBuilder.processArray(...)` resolved the element type of simple array items through `MapperUtil.getSimpleType(...)`, which has no binary detection. A single binary property was already handled correctly (`MultipartFile` via `processStringProperty`), but the array path fell through to `String`.

## Change

- `ModelBuilder.processArray`: detect binary array items with `ApiTool.isBinary(items)` and map them to `TypeConstants.MULTIPART_FILE`. `ApiTool.isBinary` already covers both OpenAPI 3.0 (`format: binary`) and 3.1 (`contentEncoding` / `contentMediaType`). The `MultipartFile` import is added automatically since `getTypeImports` walks the inner type of the collection.

## Test

- Added an `attachments: array of {string, binary}` property to the `Document` schema in the existing `testSimpleBuild` fixture, and updated the asserted golden `DocumentDTO.java` to expect `List<MultipartFile>`.
- Full engine suite green: `Tests run: 118, Failures: 0, Errors: 0`.

## Before / after

```java
// before
private List<String> attachments;
// after
private List<MultipartFile> attachments;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Version

Bumps the project version `6.6.0` → `6.6.1` (patch, bugfix) across the engine, Maven plugin and Gradle plugin.
