### PR TITLE
Grant pull-requests write permission to PR comment workflows

### DIFF
--- a/.github/workflows/gradle-pr.yml
+++ b/.github/workflows/gradle-pr.yml
@@ -6,6 +6,10 @@ on:
 
 concurrency: pr-gradle-${{ github.event.pull_request.id }}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -6,6 +6,10 @@ on:
 
 concurrency: pr-${{ github.event.pull_request.id }}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -6,6 +6,10 @@ on:
 
 concurrency: pr-${{ github.event.pull_request.id }}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Fixes the CI failure `Error: Resource not accessible by integration` raised by `thollander/actions-comment-pull-request` in the PR workflows.

## Why

The PR workflows post comments (review label warnings, build/version warnings) but declare **no `permissions` block**, so they inherit the repository's default read-only `GITHUB_TOKEN` and cannot create/update PR comments. The **"Pull Request Approved"** workflow (`pr-review.yml`) fails on every approval at the `check-labels` → *Warn about missing labels* step:

```
Run thollander/actions-comment-pull-request@v2
No comment has been found with asked pattern. Creating a new comment.
Error: Resource not accessible by integration
```

`maven-pr.yml` and `gradle-pr.yml` share the same latent problem for release PRs.

## Change

Add a minimal permissions block to the three PR workflows:

```yaml
permissions:
  contents: read
  pull-requests: write
```

- `pr-review.yml` — runs on `pull_request_review` (base-repo context), so the write scope now applies and the comment succeeds.
- `maven-pr.yml`, `gradle-pr.yml` — same block for consistency, fixing the comment steps for same-repo (release) PRs.

No source or generated-code changes; project version is intentionally not bumped (CI-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
