### PR TITLE
Default model package to <apiPackage>.model when modelPackage is unset

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.6.4</version>
+  <version>6.6.5</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/OpenApiGenerator.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/OpenApiGenerator.java
@@ -115,6 +115,13 @@ public class OpenApiGenerator {
     }
 
     templateFactory.calculateJavaEEPackage(springBootVersion);
+    // Resolve the model package up front so the API interface imports models from the same
+    // package they are actually written to (the interface is rendered before the models).
+    // Only when a package can be derived from the spec (explicit modelPackage, or apiPackage);
+    // otherwise the legacy default resolution is preserved untouched.
+    if (StringUtils.isNotBlank(specFile.getApiPackage()) || StringUtils.isNotBlank(specFile.getModelPackage())) {
+      templateFactory.setModelPackageName(processModelPackage(specFile.getApiPackage(), specFile.getModelPackage()));
+    }
     final var globalObject = createApiTemplate(specFile, openAPI);
 
     createModelTemplate(specFile, openAPI, globalObject);
@@ -165,7 +172,7 @@ public class OpenApiGenerator {
   }
 
   private void createModelTemplate(final SpecFile specFile, final JsonNode openAPI, final GlobalObject globalObject) {
-    final var modelPackage = processModelPackage(specFile.getModelPackage());
+    final var modelPackage = processModelPackage(specFile.getApiPackage(), specFile.getModelPackage());
 
     final var totalSchemas = OpenApiUtil.processPaths(openAPI, globalObject.getSchemaMap(), specFile);
     templateFactory.setModelPackageName(modelPackage);
@@ -197,10 +204,12 @@ public class OpenApiGenerator {
     }
   }
 
-  private String processModelPackage(final String modelPackage) {
-    var modelReturnPackage = "";
+  private String processModelPackage(final String apiPackage, final String modelPackage) {
+    final String modelReturnPackage;
     if (StringUtils.isNotBlank(modelPackage)) {
       modelReturnPackage = modelPackage.trim();
+    } else if (StringUtils.isNotBlank(apiPackage)) {
+      modelReturnPackage = apiPackage.trim() + ".model";
     } else if (groupId != null) {
       modelReturnPackage = groupId + ".model";
     } else {
@@ -256,10 +265,16 @@ public class OpenApiGenerator {
     final String parentPackage = modelPackage.substring(modelPackage.lastIndexOf(".") + 1);
     final var schemaObjectIt = MapperContentUtil
                                    .mapComponentToSchemaObject(basicSchemaMap, schemaName, model, parentPackage, specFile, this.baseDir).iterator();
+    // Write to the resolved model package only when it is derivable from the spec (explicit
+    // modelPackage or apiPackage); otherwise keep the legacy default (raw modelPackage, which
+    // the writer defaults to the plugin's base package).
+    final String writeModelPackage =
+        StringUtils.isNotBlank(specFile.getModelPackage()) || StringUtils.isNotBlank(specFile.getApiPackage())
+            ? modelPackage : specFile.getModelPackage();
     if (schemaObjectIt.hasNext()) {
-      writeSchemaObject(specFile.isUseLombokModelAnnotation(), specFile.getModelPackage(), schemaName, schemaObjectIt.next());
+      writeSchemaObject(specFile.isUseLombokModelAnnotation(), writeModelPackage, schemaName, schemaObjectIt.next());
     }
-    schemaObjectIt.forEachRemaining(schemaObj -> writeSchemaObject(specFile.isUseLombokModelAnnotation(), specFile.getModelPackage(), null, schemaObj));
+    schemaObjectIt.forEachRemaining(schemaObj -> writeSchemaObject(specFile.isUseLombokModelAnnotation(), writeModelPackage, null, schemaObj));
 
   }
 

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -91,6 +91,11 @@ public final class OpenApiGeneratorFixtures {
 					.apiPackage("com.sngular.multifileplugin.testbinarybodyresource")
 					.useLombokModelAnnotation(false).build());
 
+	static final List<SpecFile> TEST_MODEL_PACKAGE_DEFAULT = List
+			.of(SpecFile.builder().filePath("openapigenerator/testModelPackageDefault/api-test.yml")
+					.apiPackage("com.sngular.multifileplugin.testmodelpackagedefault")
+					.useLombokModelAnnotation(false).build());
+
 	static final List<SpecFile> TEST_REACTIVE_BINARY_BODY_RESOURCE = List
 			.of(SpecFile.builder().filePath("openapigenerator/testReactiveBinaryBodyResource/api-test.yml")
 					.apiPackage("com.sngular.multifileplugin.testreactivebinarybodyresource")
@@ -615,6 +620,24 @@ public final class OpenApiGeneratorFixtures {
 		return path -> commonTest(path, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API,
 				DEFAULT_MODEL_API, Collections.emptyList(), null);
 
+	}
+
+	static Function<Path, Boolean> validateModelPackageDefault() {
+
+		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/testmodelpackagedefault";
+
+		final String DEFAULT_MODEL_API = "generated/com/sngular/multifileplugin/testmodelpackagedefault/model";
+
+		final String COMMON_PATH = "openapigenerator/testModelPackageDefault/";
+
+		final String ASSETS_PATH = COMMON_PATH + "assets/";
+
+		final List<String> expectedTestApiFile = List.of(ASSETS_PATH + "ThingApi.java");
+
+		final List<String> expectedTestApiModelFiles = List.of(ASSETS_PATH + "Thing.java");
+
+		return path -> commonTest(path, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API,
+				DEFAULT_MODEL_API, Collections.emptyList(), null);
 	}
 
 	static Function<Path, Boolean> validateBinaryBodyResource() {

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
@@ -67,6 +67,8 @@ class OpenApiGeneratorTest {
             OpenApiGeneratorFixtures.validateReactiveFormDataMultipart()),
         Arguments.of("testBinaryBodyResource", OpenApiGeneratorFixtures.TEST_BINARY_BODY_RESOURCE,
             OpenApiGeneratorFixtures.validateBinaryBodyResource()),
+        Arguments.of("testModelPackageDefault", OpenApiGeneratorFixtures.TEST_MODEL_PACKAGE_DEFAULT,
+            OpenApiGeneratorFixtures.validateModelPackageDefault()),
         Arguments.of("testReactiveBinaryBodyResource", OpenApiGeneratorFixtures.TEST_REACTIVE_BINARY_BODY_RESOURCE,
             OpenApiGeneratorFixtures.validateReactiveBinaryBodyResource()),
         Arguments.of("testApiTagsGeneration", OpenApiGeneratorFixtures.TEST_API_TAGS_GENERATION,

--- a/multiapi-engine/src/test/resources/openapigenerator/testModelPackageDefault/api-test.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testModelPackageDefault/api-test.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.2
+info:
+  title: Testing default model package
+  version: 1.0.0
+servers:
+- url: http://localhost/v1
+paths:
+  /thing:
+    get:
+      tags:
+      - test
+      operationId: getThing
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        name:
+          type: string
+        count:
+          type: integer

--- a/multiapi-engine/src/test/resources/openapigenerator/testModelPackageDefault/assets/Thing.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testModelPackageDefault/assets/Thing.java
@@ -1,0 +1,94 @@
+package com.sngular.multifileplugin.testmodelpackagedefault.model;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonDeserialize(builder = Thing.ThingBuilder.class)
+public class Thing {
+
+  @JsonProperty(value ="name")
+  private String name;
+  @JsonProperty(value ="count")
+  private Integer count;
+
+  private Thing(ThingBuilder builder) {
+    this.name = builder.name;
+    this.count = builder.count;
+
+  }
+
+  public static Thing.ThingBuilder builder() {
+    return new Thing.ThingBuilder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class ThingBuilder {
+
+    private String name;
+    private Integer count;
+
+    public Thing.ThingBuilder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Thing.ThingBuilder count(Integer count) {
+      this.count = count;
+      return this;
+    }
+
+    public Thing build() {
+      Thing thing = new Thing(this);
+      return thing;
+    }
+  }
+
+  @Schema(name = "name", required = false)
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Schema(name = "count", required = false)
+  public Integer getCount() {
+    return count;
+  }
+  public void setCount(Integer count) {
+    this.count = count;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Thing thing = (Thing) o;
+    return Objects.equals(this.name, thing.name) && Objects.equals(this.count, thing.count);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, count);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Thing{");
+    sb.append(" name:").append(name).append(",");
+    sb.append(" count:").append(count);
+    sb.append("}");
+    return sb.toString();
+  }
+
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testModelPackageDefault/assets/ThingApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testModelPackageDefault/assets/ThingApi.java
@@ -1,0 +1,45 @@
+package com.sngular.multifileplugin.testmodelpackagedefault;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import com.sngular.multifileplugin.testmodelpackagedefault.model.Thing;
+
+public interface ThingApi {
+
+  /**
+   * GET /thing
+   * @return  OK; (status code 200)
+   */
+
+  @Operation(
+    operationId = "getThing",
+    tags = {"test"},
+    responses = {
+      @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Thing.class)))
+    }
+  )
+  @RequestMapping(
+    method = RequestMethod.GET,
+    value = "/thing",
+    produces = {"application/json"}
+  )
+
+  default ResponseEntity<Thing> getThing() {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+}

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.6.4'
+version = '6.6.5'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.6.4'
+  implementation 'com.sngular:multiapi-engine:6.6.5'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.4'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.5'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.6.4</version>
+    <version>6.6.5</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.6.4</version>
+      <version>6.6.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## What

When only `apiPackage` is set (no `modelPackage`), the generated controller now imports models from the same package they are written to — defaulting to `<apiPackage>.model`. Closes #395.

## Why

Previously, with `modelPackage` unset, the controller imported `com.acme.api.Thing` while the model was written to `com.sngular.apigenerator.openapi.Thing` (the plugin default) — the import pointed at a non-existent class, so the generated code did not compile.

There were three inconsistent resolutions when `modelPackage` was blank:
- the interface import fell back to the api package;
- the model files were written from the raw (empty) `specFile.getModelPackage()`, defaulted to the plugin's default API package;
- `processModelPackage` computed `groupId + ".model"` but it was applied only after the interface had already been rendered.

## Change (`OpenApiGenerator`)

- `processModelPackage` now takes `apiPackage` and defaults to `<apiPackage>.model` when `modelPackage` is blank (then `groupId + ".model"`, then the plugin default).
- The resolved package is set via `setModelPackageName` **before** the API interface is rendered, so imports match.
- Model files are written to the resolved package (using the computed value, not the raw `specFile.getModelPackage()`).

When `modelPackage` is set explicitly, behavior is unchanged (all existing goldens pass untouched).

## Before / after (only `apiPackage = ...testmodelpackagedefault`, no `modelPackage`)

```java
// before
import com.sngular.multifileplugin.testmodelpackagedefault.Thing;   // model actually at com.sngular.apigenerator.openapi
// after
import com.sngular.multifileplugin.testmodelpackagedefault.model.Thing;   // model at ...testmodelpackagedefault.model
```

## Test

- New `testModelPackageDefault` fixture + goldens (`ThingApi.java`, `model/Thing.java`).
- Full engine suite green: `Tests run: 122, Failures: 0, Errors: 0`.

## Version

Bumps `6.6.4` → `6.6.5` across engine, Maven plugin and Gradle plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
