### PR TITLE
Support Spring Boot 4 (Jackson 3 + Spring Framework 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,7 @@ be saved in the api of the project.
 | clientPackage                                       | Path where the RestClient and/or WebClient are located                                                                                                                                                                                                                          | com.sngular.apigenerator.openapi.client |
 | [generatedSourcesFolder](#generated-sources-folder) | Name of the folder, inside `target`, where the files will be located. By defaut it's `generated-sources`                                                                                                                                                                        | generated-sources                       |
 | overwriteModel                                      | Boolean value to decide if you want your models to be overwritten if two or more models have the same name. True means that models will be overwritten and if false is set, it will throw an exception if two models share the same name. It is initialized to false by default | false                                   |
-| springBootVersion                                   | The version of spring to target during generation. It's default value is `2`.                                                                                                                                                                                                   | 3                                       |
+| springBootVersion                                   | The version of spring to target during generation. It's default value is `2`. Values `>= 3` emit `jakarta.*` imports (instead of `javax.*`); values `>= 4` additionally emit Jackson 3 (`tools.jackson.*`) and Spring Framework 7 imports (see below).                            | 4                                       |
 
 We must clarify that the options to make calls are configured under the
 RestClient or WebClient specifications as indicated above in the configuration
@@ -762,6 +762,28 @@ options. If several of the APIs to be generated are defined under the same call
 option, a single RestClient/Webclient will be generated for all of them, which
 is initialized with the specific options needed within the class that defines
 each API.
+
+### Spring Boot 4 / Jackson 3 support
+
+Setting `springBootVersion` to `4` (or higher) targets Spring Boot 4
+(Spring Framework 7), which ships **Jackson 3** as its default JSON stack.
+When this is set, the generated code changes as follows:
+
+- Jackson `databind` imports are emitted under `tools.jackson.*` instead of
+  `com.fasterxml.jackson.*` (e.g. `tools.jackson.databind.annotation.JsonDeserialize`).
+- Jackson **annotations** keep their original coordinates
+  (`com.fasterxml.jackson.annotation.*`, such as `@JsonProperty`), matching
+  Jackson 3's own packaging.
+- Generated RestClient/WebClient build an immutable `JsonMapper` via
+  `JsonMapper.builder()` (the Jackson 2 mutable `ObjectMapper` API is gone), and
+  the reactive WebClient uses the Spring Framework 7 codecs
+  (`JacksonJsonEncoder`/`JacksonJsonDecoder`).
+
+For `springBootVersion < 4` the output is unchanged and keeps targeting Jackson 2.
+
+> **Note:** Lombok-annotated models (`useLombokModelAnnotation`) rely on Lombok's
+> `@Jacksonized`, which does not yet support Jackson 3. Combining Lombok models
+> with `springBootVersion = 4` is therefore not supported.
 
 ### Usage considerations
 

--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.6.5</version>
+  <version>6.6.6</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/handler/BaseAsyncApiHandler.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/handler/BaseAsyncApiHandler.java
@@ -247,6 +247,7 @@ public abstract class BaseAsyncApiHandler {
 
   protected void processJavaEEPackage(final Integer springBootVersion) {
     templateFactory.calculateJavaEEPackage(springBootVersion);
+    templateFactory.calculateJacksonPackage(springBootVersion);
   }
 
   protected String evaluatePackage(final OperationParameterObject operation) {

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/template/TemplateFactory.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/asyncapi/template/TemplateFactory.java
@@ -203,6 +203,19 @@ public class TemplateFactory extends CommonTemplateFactory {
     }
   }
 
+  public final void calculateJacksonPackage(final Integer springBootVersion) {
+    // Spring Boot 4 (Spring Framework 7) ships Jackson 3, which relocated its databind/core
+    // packages from com.fasterxml.jackson to tools.jackson. Jackson annotations keep the old
+    // coordinates, so only the databind package is switched here.
+    if (4 <= springBootVersion) {
+      addToRoot("jacksonPackage", "tools.jackson");
+      addToRoot("isJackson3", Boolean.TRUE);
+    } else {
+      addToRoot("jacksonPackage", "com.fasterxml.jackson");
+      addToRoot("isJackson3", Boolean.FALSE);
+    }
+  }
+
   public final void clearData() {
     cleanData();
     publishMethods.clear();

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/OpenApiGenerator.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/OpenApiGenerator.java
@@ -115,6 +115,7 @@ public class OpenApiGenerator {
     }
 
     templateFactory.calculateJavaEEPackage(springBootVersion);
+    templateFactory.calculateJacksonPackage(springBootVersion);
     // Resolve the model package up front so the API interface imports models from the same
     // package they are actually written to (the interface is rendered before the models).
     // Only when a package can be derived from the spec (explicit modelPackage, or apiPackage);

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/template/TemplateFactory.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/template/TemplateFactory.java
@@ -105,6 +105,19 @@ public class TemplateFactory extends CommonTemplateFactory {
     }
   }
 
+  public final void calculateJacksonPackage(final Integer springBootVersion) {
+    // Spring Boot 4 (Spring Framework 7) ships Jackson 3, which relocated its databind/core
+    // packages from com.fasterxml.jackson to tools.jackson. Jackson annotations keep the old
+    // coordinates, so only the databind package is switched here.
+    if (4 <= springBootVersion) {
+      addToRoot("jacksonPackage", "tools.jackson");
+      addToRoot("isJackson3", Boolean.TRUE);
+    } else {
+      addToRoot("jacksonPackage", "com.fasterxml.jackson");
+      addToRoot("isJackson3", Boolean.FALSE);
+    }
+  }
+
   public final void setPackageName(final String packageName) {
     addToRoot("package", packageName);
   }

--- a/multiapi-engine/src/main/resources/templates/model/templateSchema.ftlh
+++ b/multiapi-engine/src/main/resources/templates/model/templateSchema.ftlh
@@ -80,8 +80,8 @@ package ${packageModel};
 
 import java.util.Objects;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import ${jacksonPackage}.databind.annotation.JsonDeserialize;
+import ${jacksonPackage}.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 <#list schema.fieldObjectList as field>
   <#if field.enumValues?has_content>

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -818,6 +818,50 @@ public final class OpenApiGeneratorFixtures {
 						CLIENT_MODEL_API, Collections.emptyList(), null);
 	}
 
+	static Function<Path, Boolean> validateRestClientGenerationSpringBoot4() {
+
+		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/restclient";
+
+		final String CLIENT_TARGET_API = "generated/com/sngular/multifileplugin/restclient/client";
+
+		final String CLIENT_AUTH_API = "generated/com/sngular/multifileplugin/restclient/client/auth";
+
+		final String MODEL_TARGET_API = "generated/com/sngular/multifileplugin/restclient/model";
+
+		final String COMMON_PATH = "openapigenerator/testRestClientApiGeneration/";
+
+		final String ASSETS_PATH = COMMON_PATH + "assets/springboot4/";
+
+		final List<String> expectedTestApiFile = List.of(ASSETS_PATH + "TestApi.java");
+
+		final List<String> expectedTestClientApiFile = List.of(ASSETS_PATH + "client/ApiRestClient.java");
+
+		final List<String> expectedTestClientAuthModelFiles = List.of(ASSETS_PATH + "client/auth/Authentication.java",
+				ASSETS_PATH + "client/auth/HttpBasicAuth.java");
+
+		final List<String> expectedModelFiles = List.of(ASSETS_PATH + "model/ApiErrorDTO.java",
+				ASSETS_PATH + "model/ApiTestDTO.java", ASSETS_PATH + "model/ApiTestInfoDTO.java");
+
+		return path -> commonTest(path, expectedTestApiFile, expectedModelFiles, DEFAULT_TARGET_API, MODEL_TARGET_API,
+				Collections.emptyList(), null)
+				&& commonTest(path, expectedTestClientApiFile, expectedTestClientAuthModelFiles, CLIENT_TARGET_API,
+						CLIENT_AUTH_API, Collections.emptyList(), null);
+	}
+
+	static Function<Path, Boolean> validateWebClientGenerationSpringBoot4() {
+
+		final String CLIENT_TARGET_API = "generated/com/sngular/apigenerator/openapi/client";
+
+		final String COMMON_PATH = "openapigenerator/testWebClientApiGeneration/";
+
+		final String ASSETS_PATH = COMMON_PATH + "assets/springboot4/";
+
+		final List<String> expectedClientFile = List.of(ASSETS_PATH + "client/ApiWebClient.java");
+
+		return path -> commonTest(path, expectedClientFile, Collections.emptyList(), CLIENT_TARGET_API, null,
+				Collections.emptyList(), null);
+	}
+
 	static Function<Path, Boolean> validateRestClientWithRequestBodyGeneration() {
 
 		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/restclientWithRequestObjects";

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorSpringBoot4Test.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorSpringBoot4Test.java
@@ -1,0 +1,60 @@
+/*
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  * License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.sngular.api.generator.plugin.openapi;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.sngular.api.generator.plugin.openapi.parameter.SpecFile;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Spring Boot 4 (Spring Framework 7 + Jackson 3) code generation. Verifies that the generated
+ * clients import {@code tools.jackson.*} databind classes, build the immutable {@code JsonMapper},
+ * use the Spring 7 reactive codecs, while Jackson annotations stay on {@code com.fasterxml.jackson.annotation}.
+ */
+class OpenApiGeneratorSpringBoot4Test {
+
+  private static final int SPRING_BOOT_VERSION = 4;
+
+  @TempDir(cleanup = CleanupMode.NEVER)
+  static Path baseDir;
+
+  private static OpenApiGenerator openApiGenerator;
+
+  @BeforeAll
+  static void setup() {
+    openApiGenerator =
+        new OpenApiGenerator(SPRING_BOOT_VERSION, Boolean.TRUE, new File(baseDir.toAbsolutePath() + File.separator + OpenApiGeneratorFixtures.TARGET),
+            OpenApiGeneratorFixtures.GENERATED, "groupId", Path.of("src", "test", "resources").toFile());
+  }
+
+  static Stream<Arguments> fileSpecToProcess() {
+    return Stream.of(
+        Arguments.of("testRestClientApiGeneration", OpenApiGeneratorFixtures.TEST_REST_CLIENT_GENERATION,
+            OpenApiGeneratorFixtures.validateRestClientGenerationSpringBoot4()),
+        Arguments.of("testWebClientApiGeneration", OpenApiGeneratorFixtures.TEST_WEB_CLIENT_GENERATION,
+            OpenApiGeneratorFixtures.validateWebClientGenerationSpringBoot4())
+    );
+  }
+
+  @ParameterizedTest(name = "Test {index} - Spring Boot 4 File Spec for case {0}")
+  @MethodSource("fileSpecToProcess")
+  void processFileSpec(final String type, final List<SpecFile> specFileList, final Function<Path, Boolean> validation) {
+    openApiGenerator.processFileSpec(specFileList);
+    Assertions.assertThat(validation.apply(baseDir)).isTrue();
+  }
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/TestApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/TestApi.java
@@ -1,0 +1,144 @@
+package com.sngular.multifileplugin.restclient;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.sngular.multifileplugin.restclient.client.ApiRestClient;
+
+import com.sngular.multifileplugin.restclient.model.ApiTestDTO;
+import com.sngular.multifileplugin.restclient.model.ApiErrorDTO;
+import com.sngular.multifileplugin.restclient.model.ApiTestInfoDTO;
+
+import com.sngular.multifileplugin.restclient.client.auth.Authentication;
+import com.sngular.multifileplugin.restclient.client.auth.HttpBasicAuth;
+
+import org.springframework.stereotype.Component;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Component()
+public class TestApi {
+
+  private ApiRestClient apiRestClient;
+
+  private Map<String, Authentication> authenticationsApi;
+
+  public TestApi() {
+    this.init();
+  }
+
+  protected void init() {
+    this.authenticationsApi = new HashMap<String, Authentication>();
+    this.authenticationsApi.put("BasicAuth", new HttpBasicAuth());
+    this.apiRestClient = new ApiRestClient(authenticationsApi);
+  }
+
+  /**
+   * GET /test: List all available test
+   * @return A paged array of tests; (status code 200)
+   * @throws RestClientException if an error occurs while attempting to invoke the API
+   */
+  public ApiTestDTO listTest() throws RestClientException {
+    return listTestWithHttpInfo().getBody();
+  }
+
+  public ResponseEntity<ApiTestDTO> listTestWithHttpInfo() throws RestClientException {
+
+    Object postBody = null;
+    final Map<String, Object> uriVariables = new HashMap<String, Object>();
+
+    final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+    final HttpHeaders headerParams = new HttpHeaders();
+    final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
+    final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
+
+    final String[] localVarAccepts = {"application/json"};
+    final List<MediaType> localVarAccept = apiRestClient.selectHeaderAccept(localVarAccepts);
+    final String[] localVarContentTypes = {};
+    final MediaType localVarContentType = apiRestClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {"BasicAuth"};
+
+    ParameterizedTypeReference<ApiTestDTO> localVarReturnType = new ParameterizedTypeReference<ApiTestDTO>() {};
+    return apiRestClient.invokeAPI("http://localhost:8080/v1","/test", HttpMethod.GET, uriVariables, queryParams, postBody, headerParams, cookieParams, formParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+  }
+
+  /**
+   * GET /test/{testId}: Info for a specific test
+   * @param testId The id of the test to retrieve (required)
+   * @param pathVariableDate   (required)
+   * @param QueryParamDate   (required)
+   * @return Expected response to a valid request; (status code 200)
+   * @throws RestClientException if an error occurs while attempting to invoke the API
+   */
+  public ApiTestInfoDTO showTestById(Integer testId, LocalDateTime pathVariableDate, LocalDateTime QueryParamDate) throws RestClientException {
+    return showTestByIdWithHttpInfo(testId, pathVariableDate, QueryParamDate).getBody();
+  }
+
+  public ResponseEntity<ApiTestInfoDTO> showTestByIdWithHttpInfo(Integer testId, LocalDateTime pathVariableDate, LocalDateTime QueryParamDate) throws RestClientException {
+
+    Object postBody = null;
+    final Map<String, Object> uriVariables = new HashMap<String, Object>();
+
+    uriVariables.put("testId",  testId);
+    uriVariables.put("pathVariableDate",  pathVariableDate);
+    final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+    final HttpHeaders headerParams = new HttpHeaders();
+    final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
+    final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
+
+    queryParams.putAll(apiRestClient.parameterToMultiValueMap( null, "QueryParamDate", QueryParamDate));
+    final String[] localVarAccepts = {"application/json"};
+    final List<MediaType> localVarAccept = apiRestClient.selectHeaderAccept(localVarAccepts);
+    final String[] localVarContentTypes = {};
+    final MediaType localVarContentType = apiRestClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {"BasicAuth"};
+
+    ParameterizedTypeReference<ApiTestInfoDTO> localVarReturnType = new ParameterizedTypeReference<ApiTestInfoDTO>() {};
+    return apiRestClient.invokeAPI("http://localhost:8080/v1","/test/{testId}", HttpMethod.GET, uriVariables, queryParams, postBody, headerParams, cookieParams, formParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+  }
+
+  /**
+   * DELETE /test/{testId}: Info for a specific test
+   * @param testId The id of the test to retrieve (required)
+   * @return No content response; (status code 204)
+   * @throws RestClientException if an error occurs while attempting to invoke the API
+   */
+  public void deleteTestById(Integer testId) throws RestClientException {
+    deleteTestByIdWithHttpInfo(testId);
+  }
+
+  public ResponseEntity<Void> deleteTestByIdWithHttpInfo(Integer testId) throws RestClientException {
+
+    Object postBody = null;
+    final Map<String, Object> uriVariables = new HashMap<String, Object>();
+
+    uriVariables.put("testId",  testId);
+    final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+    final HttpHeaders headerParams = new HttpHeaders();
+    final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
+    final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
+
+    final String[] localVarAccepts = {"application/json"};
+    final List<MediaType> localVarAccept = apiRestClient.selectHeaderAccept(localVarAccepts);
+    final String[] localVarContentTypes = {};
+    final MediaType localVarContentType = apiRestClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {"BasicAuth"};
+
+    ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
+    return apiRestClient.invokeAPI("http://localhost:8080/v1","/test/{testId}", HttpMethod.DELETE, uriVariables, queryParams, postBody, headerParams, cookieParams, formParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/client/ApiRestClient.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/client/ApiRestClient.java
@@ -1,4 +1,4 @@
-package ${packageClient};
+package com.sngular.multifileplugin.restclient.client;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -26,16 +26,9 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.TimeZone;
 
-import ${jacksonPackage}.databind.DeserializationFeature;
-<#if isJackson3>
-import ${jacksonPackage}.databind.json.JsonMapper;
-<#else>
-import ${jacksonPackage}.databind.ObjectMapper;
-</#if>
-import ${jacksonPackage}.databind.util.StdDateFormat;
-<#if !isJackson3>
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-</#if>
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.util.StdDateFormat;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -61,15 +54,10 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriComponentsBuilder;
-<#if isJackson3>
 import org.springframework.http.converter.json.AbstractJacksonHttpMessageConverter;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
-<#else>
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
-</#if>
 
-import ${packageAuth}.Authentication;
+import com.sngular.multifileplugin.restclient.client.auth.Authentication;
 
 @Component
 public class ApiRestClient {
@@ -132,7 +120,6 @@ public class ApiRestClient {
     return dateFormat;
   }
 
-<#if isJackson3>
   private static JsonMapper createDefaultObjectMapper(final DateFormat defaultDateFormat) {
     DateFormat dateFormat = defaultDateFormat;
     if (Objects.isNull(defaultDateFormat)) {
@@ -152,29 +139,6 @@ public class ApiRestClient {
     restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(restTemplate.getRequestFactory()));
     return restTemplate;
   }
-<#else>
-  private static void createDefaultObjectMapper(final DateFormat defaultDateFormat, final AbstractJackson2HttpMessageConverter converter) {
-    DateFormat dateFormat = defaultDateFormat;
-    if (Objects.isNull(defaultDateFormat)) {
-      dateFormat = createDefaultDateFormat();
-    }
-    final ObjectMapper mapper = converter.getObjectMapper();
-    mapper.setDateFormat(dateFormat);
-    mapper.registerModule(new JavaTimeModule());
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-  }
-
-  protected RestTemplate buildRestTemplate() {
-    final RestTemplate restTemplate = new RestTemplate();
-    for(HttpMessageConverter converter:restTemplate.getMessageConverters()) {
-      if(converter instanceof AbstractJackson2HttpMessageConverter) {
-        createDefaultObjectMapper(this.dateFormat, (AbstractJackson2HttpMessageConverter) converter);
-      }
-    }
-    restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(restTemplate.getRequestFactory()));
-    return restTemplate;
-  }
-</#if>
 
   public ApiRestClient addDefaultHeader(final String name, final String value) {
     if (defaultHeaders.containsKey(name)) {

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/client/auth/Authentication.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/client/auth/Authentication.java
@@ -1,0 +1,9 @@
+package com.sngular.multifileplugin.restclient.client.auth;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.MultiValueMap;
+
+public interface Authentication {
+
+  public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams, MultiValueMap<String, String> cookieParams);
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/client/auth/HttpBasicAuth.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/client/auth/HttpBasicAuth.java
@@ -1,0 +1,37 @@
+package com.sngular.multifileplugin.restclient.client.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.Base64Utils;
+import org.springframework.util.MultiValueMap;
+
+public class HttpBasicAuth implements Authentication {
+  private String username;
+  private String password;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  @Override
+  public void applyToParams(MultiValueMap<String, String> queryParams, HttpHeaders headerParams, MultiValueMap<String, String> cookieParams) {
+    if (username == null && password == null) {
+      return;
+    }
+    String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
+    headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/model/ApiErrorDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/model/ApiErrorDTO.java
@@ -1,0 +1,106 @@
+package com.sngular.multifileplugin.restclient.model;
+
+import java.util.Objects;
+
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import com.sngular.multifileplugin.restclient.model.exception.ModelClassException;
+import com.sngular.multifileplugin.restclient.model.customvalidator.NotNull;
+
+@JsonDeserialize(builder = ApiErrorDTO.ApiErrorDTOBuilder.class)
+public class ApiErrorDTO {
+
+  @JsonProperty(value ="code")
+  @NotNull
+  private final Integer code;
+  @JsonProperty(value ="message")
+  @NotNull
+  private final String message;
+
+  private ApiErrorDTO(ApiErrorDTOBuilder builder) {
+    this.code = builder.code;
+    this.message = builder.message;
+
+    validateRequiredAttributes();
+  }
+
+  public static ApiErrorDTO.ApiErrorDTOBuilder builder() {
+    return new ApiErrorDTO.ApiErrorDTOBuilder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class ApiErrorDTOBuilder {
+
+    private Integer code;
+    private String message;
+
+    public ApiErrorDTO.ApiErrorDTOBuilder code(Integer code) {
+      this.code = code;
+      return this;
+    }
+
+    public ApiErrorDTO.ApiErrorDTOBuilder message(String message) {
+      this.message = message;
+      return this;
+    }
+
+    public ApiErrorDTO build() {
+      ApiErrorDTO apiErrorDTO = new ApiErrorDTO(this);
+      return apiErrorDTO;
+    }
+  }
+
+  @Schema(name = "code", required = true)
+  public Integer getCode() {
+    return code;
+  }
+
+  @Schema(name = "message", required = true)
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ApiErrorDTO apiErrorDTO = (ApiErrorDTO) o;
+    return Objects.equals(this.code, apiErrorDTO.code) && Objects.equals(this.message, apiErrorDTO.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(code, message);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("ApiErrorDTO{");
+    sb.append(" code:").append(code).append(",");
+    sb.append(" message:").append(message);
+    sb.append("}");
+    return sb.toString();
+  }
+
+  private void validateRequiredAttributes() {
+    boolean satisfiedCondition = true;
+
+    if (!Objects.nonNull(this.code)) {
+      satisfiedCondition = false;
+    } else if (!Objects.nonNull(this.message)) {
+      satisfiedCondition = false;
+    }
+
+    if (!satisfiedCondition) {
+      throw new ModelClassException("ApiErrorDTO");
+    }
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/model/ApiTestDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/model/ApiTestDTO.java
@@ -1,0 +1,106 @@
+package com.sngular.multifileplugin.restclient.model;
+
+import java.util.Objects;
+
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import com.sngular.multifileplugin.restclient.model.exception.ModelClassException;
+import com.sngular.multifileplugin.restclient.model.customvalidator.NotNull;
+
+@JsonDeserialize(builder = ApiTestDTO.ApiTestDTOBuilder.class)
+public class ApiTestDTO {
+
+  @JsonProperty(value ="name")
+  @NotNull
+  private final String name;
+  @JsonProperty(value ="id")
+  @NotNull
+  private final Integer id;
+
+  private ApiTestDTO(ApiTestDTOBuilder builder) {
+    this.name = builder.name;
+    this.id = builder.id;
+
+    validateRequiredAttributes();
+  }
+
+  public static ApiTestDTO.ApiTestDTOBuilder builder() {
+    return new ApiTestDTO.ApiTestDTOBuilder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class ApiTestDTOBuilder {
+
+    private String name;
+    private Integer id;
+
+    public ApiTestDTO.ApiTestDTOBuilder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public ApiTestDTO.ApiTestDTOBuilder id(Integer id) {
+      this.id = id;
+      return this;
+    }
+
+    public ApiTestDTO build() {
+      ApiTestDTO apiTestDTO = new ApiTestDTO(this);
+      return apiTestDTO;
+    }
+  }
+
+  @Schema(name = "name", required = true)
+  public String getName() {
+    return name;
+  }
+
+  @Schema(name = "id", required = true)
+  public Integer getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ApiTestDTO apiTestDTO = (ApiTestDTO) o;
+    return Objects.equals(this.name, apiTestDTO.name) && Objects.equals(this.id, apiTestDTO.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, id);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("ApiTestDTO{");
+    sb.append(" name:").append(name).append(",");
+    sb.append(" id:").append(id);
+    sb.append("}");
+    return sb.toString();
+  }
+
+  private void validateRequiredAttributes() {
+    boolean satisfiedCondition = true;
+
+    if (!Objects.nonNull(this.name)) {
+      satisfiedCondition = false;
+    } else if (!Objects.nonNull(this.id)) {
+      satisfiedCondition = false;
+    }
+
+    if (!satisfiedCondition) {
+      throw new ModelClassException("ApiTestDTO");
+    }
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/model/ApiTestInfoDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestClientApiGeneration/assets/springboot4/model/ApiTestInfoDTO.java
@@ -1,0 +1,117 @@
+package com.sngular.multifileplugin.restclient.model;
+
+import java.util.Objects;
+
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.ArrayList;
+import com.sngular.multifileplugin.restclient.model.exception.ModelClassException;
+import com.sngular.multifileplugin.restclient.model.customvalidator.NotNull;
+
+@JsonDeserialize(builder = ApiTestInfoDTO.ApiTestInfoDTOBuilder.class)
+public class ApiTestInfoDTO {
+
+  @JsonProperty(value ="testers")
+  private List<String> testers;
+  @JsonProperty(value ="testName")
+  @NotNull
+  private final String testName;
+
+  private ApiTestInfoDTO(ApiTestInfoDTOBuilder builder) {
+    this.testers = builder.testers;
+    this.testName = builder.testName;
+
+    validateRequiredAttributes();
+  }
+
+  public static ApiTestInfoDTO.ApiTestInfoDTOBuilder builder() {
+    return new ApiTestInfoDTO.ApiTestInfoDTOBuilder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class ApiTestInfoDTOBuilder {
+
+    private List<String> testers = new ArrayList<String>();
+    private String testName;
+
+    public ApiTestInfoDTO.ApiTestInfoDTOBuilder testers(List<String> testers) {
+      if (!testers.isEmpty()) {
+        this.testers.addAll(testers);
+      }
+      return this;
+    }
+
+    public ApiTestInfoDTO.ApiTestInfoDTOBuilder tester(String tester) {
+      if (Objects.nonNull(tester)) {
+        this.testers.add(tester);
+      }
+      return this;
+    }
+
+    public ApiTestInfoDTO.ApiTestInfoDTOBuilder testName(String testName) {
+      this.testName = testName;
+      return this;
+    }
+
+    public ApiTestInfoDTO build() {
+      ApiTestInfoDTO apiTestInfoDTO = new ApiTestInfoDTO(this);
+      return apiTestInfoDTO;
+    }
+  }
+
+  @Schema(name = "testers", required = false)
+  public List<String> getTesters() {
+    return testers;
+  }
+  public void setTesters(List<String> testers) {
+    this.testers = testers;
+  }
+
+  @Schema(name = "testName", required = true)
+  public String getTestName() {
+    return testName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ApiTestInfoDTO apiTestInfoDTO = (ApiTestInfoDTO) o;
+    return Objects.equals(this.testers, apiTestInfoDTO.testers) && Objects.equals(this.testName, apiTestInfoDTO.testName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(testers, testName);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("ApiTestInfoDTO{");
+    sb.append(" testers:").append(testers).append(",");
+    sb.append(" testName:").append(testName);
+    sb.append("}");
+    return sb.toString();
+  }
+
+  private void validateRequiredAttributes() {
+    boolean satisfiedCondition = true;
+
+    if (!Objects.nonNull(this.testName)) {
+      satisfiedCondition = false;
+    }
+
+    if (!satisfiedCondition) {
+      throw new ModelClassException("ApiTestInfoDTO");
+    }
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testWebClientApiGeneration/assets/springboot4/client/ApiWebClient.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testWebClientApiGeneration/assets/springboot4/client/ApiWebClient.java
@@ -1,4 +1,4 @@
-package ${packageClient};
+package com.sngular.apigenerator.openapi.client;
 
 import java.text.DateFormat;
 import java.text.FieldPosition;
@@ -16,29 +16,17 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 
-import ${jacksonPackage}.databind.DeserializationFeature;
-<#if isJackson3>
-import ${jacksonPackage}.databind.json.JsonMapper;
-<#else>
-import ${jacksonPackage}.databind.ObjectMapper;
-</#if>
-import ${jacksonPackage}.databind.util.StdDateFormat;
-<#if !isJackson3>
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-</#if>
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.util.StdDateFormat;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ClientHttpRequest;
-<#if isJackson3>
 import org.springframework.http.codec.json.JacksonJsonDecoder;
 import org.springframework.http.codec.json.JacksonJsonEncoder;
-<#else>
-import org.springframework.http.codec.json.Jackson2JsonDecoder;
-import org.springframework.http.codec.json.Jackson2JsonEncoder;
-</#if>
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
@@ -51,8 +39,7 @@ import org.springframework.web.reactive.function.client.WebClient.ResponseSpec;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.stereotype.Component;
 
-import ${packageAuth}.Authentication;
-<#assign mapperType = (isJackson3!false)?then("JsonMapper", "ObjectMapper")>
+import com.sngular.apigenerator.openapi.client.auth.Authentication;
 
 @Component
 public class ApiWebClient {
@@ -73,7 +60,7 @@ public class ApiWebClient {
   private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
   private final WebClient webClient;
   private final DateFormat dateFormat;
-  private final ${mapperType} objectMapper;
+  private final JsonMapper objectMapper;
   private Map<String, Authentication> authentications;
 
   public ApiWebClient() {
@@ -117,35 +104,22 @@ public class ApiWebClient {
     return dateFormat;
   }
 
-  private static ${mapperType} createDefaultObjectMapper(final DateFormat dateFormat) {
+  private static JsonMapper createDefaultObjectMapper(final DateFormat dateFormat) {
     if (null == dateFormat) {
      dateFormat = createDefaultDateFormat();
     }
-<#if isJackson3>
     return JsonMapper.builder()
         .defaultDateFormat(dateFormat)
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
         .build();
-<#else>
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.setDateFormat(dateFormat);
-    mapper.registerModule(new JavaTimeModule());
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    return mapper;
-</#if>
   }
 
-  private static WebClient buildWebClient(final ${mapperType} mapper) {
+  private static WebClient buildWebClient(final JsonMapper mapper) {
     ExchangeStrategies strategies = ExchangeStrategies
       .builder()
       .codecs(clientDefaultCodecsConfigurer -> {
-<#if isJackson3>
         clientDefaultCodecsConfigurer.defaultCodecs().jacksonJsonEncoder(new JacksonJsonEncoder(mapper, MediaType.APPLICATION_JSON));
         clientDefaultCodecsConfigurer.defaultCodecs().jacksonJsonDecoder(new JacksonJsonDecoder(mapper, MediaType.APPLICATION_JSON));
-<#else>
-        clientDefaultCodecsConfigurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(mapper, MediaType.APPLICATION_JSON));
-        clientDefaultCodecsConfigurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(mapper, MediaType.APPLICATION_JSON));
-</#if>
       }).build();
     WebClient.Builder webClientBuilder = WebClient.builder().exchangeStrategies(strategies);
     return webClientBuilder.build();

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.6.5'
+version = '6.6.6'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.6.5'
+  implementation 'com.sngular:multiapi-engine:6.6.6'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.5'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.6'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.6.5</version>
+    <version>6.6.6</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.6.5</version>
+      <version>6.6.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## Problem

Spring Boot 4 (Spring Framework 7) ships **Jackson 3** as its default JSON stack. Jackson 3 relocated its `databind`/`core` packages from `com.fasterxml.jackson.*` to `tools.jackson.*`, made `ObjectMapper` immutable (builder-only construction), and folded the Java 8 date/time module into core. Spring Framework 7 also renamed its reactive JSON codecs (`Jackson2JsonEncoder` → `JacksonJsonEncoder`).

The generated code hardcoded `com.fasterxml.jackson.*` everywhere, so anything generated for a Spring Boot 4 project **did not compile**. There was already a `springBootVersion` config switching `javax` ↔ `jakarta` (`>= 3`), but nothing switched the Jackson stack.

## Approach

Gate Jackson 3 on the existing `springBootVersion` config (`>= 4`), consistent with the current `>= 3` → jakarta rule — no new config parameter.

- Add `calculateJacksonPackage()` to the OpenAPI and AsyncAPI `TemplateFactory` (mirrors `calculateJavaEEPackage`), exposing `jacksonPackage` + `isJackson3` to the templates.
- **Model template**: `databind` annotations (`JsonDeserialize`, `JsonPOJOBuilder`) move to `tools.jackson.databind.annotation`. Jackson **annotations** (`@JsonProperty`, `@JsonValue`, `@JsonFormat`) stay on `com.fasterxml.jackson.annotation` — matching Jackson 3's own packaging.
- **RestClient / WebClient templates**: build an immutable `JsonMapper` via `JsonMapper.builder()`, swap in Spring 7's `JacksonJsonHttpMessageConverter`, and use the Spring 7 reactive codecs (`JacksonJsonEncoder`/`JacksonJsonDecoder`). The Jackson 2 branches emit **byte-identical** output, so existing golden files are unchanged.
- New `OpenApiGeneratorSpringBoot4Test` (`springBootVersion = 4`) with Jackson 3 golden assets covering the RestClient, WebClient, and model-DTO output.
- README section documenting the behaviour; version bumped `6.6.5` → `6.6.6`.

## Known limitation

Lombok's `@Jacksonized` does not support Jackson 3 yet, so Lombok models + `springBootVersion = 4` is out of scope (documented in the README).

## Testing

- `multiapi-engine`: **124 tests pass** (122 existing unchanged + 2 new).
- `scs-multiapi-maven-plugin` builds and tests against engine `6.6.6`.
- Spot-checked generated SB4 output: `tools.jackson.databind.*` imports, `JsonMapper.builder()`, Spring 7 codecs — with `@JsonProperty` correctly remaining `com.fasterxml.jackson.annotation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
