### PR TITLE
Fix #371: do not generate import for java.lang.String parameters

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.6.5</version>
+  <version>6.6.6</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/model/SchemaFieldObjectType.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/model/SchemaFieldObjectType.java
@@ -47,7 +47,8 @@ public class SchemaFieldObjectType {
       new SimpleImmutableEntry<>(TypeConstants.ARRAY, "java.util.List"),
       new SimpleImmutableEntry<>(TypeConstants.MAP, "java.util.Map"),
       new SimpleImmutableEntry<>(TypeConstants.BIG_DECIMAL, "java.math.BigDecimal"),
-      new SimpleImmutableEntry<>(TypeConstants.STRING, "java.lang.String"),
+      // String is a java.lang type (implicitly imported); it must not produce an
+      // "import java.lang.String;" statement, so it has no import mapping (issue #371).
       new SimpleImmutableEntry<>(TypeConstants.LOCALDATE, "java.time.LocalDate"),
       new SimpleImmutableEntry<>(TypeConstants.LOCALDATETIME, "java.time.LocalDateTime"),
       new SimpleImmutableEntry<>(TypeConstants.ZONEDDATE, "java.time." + ZONED_DATE_TIME),

--- a/multiapi-engine/src/test/resources/openapigenerator/testCoconutSchema/assets/SchemaApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testCoconutSchema/assets/SchemaApi.java
@@ -1,6 +1,5 @@
 package com.sngular.multifileplugin.testCoconutSchema;
 
-import java.lang.String;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;

--- a/multiapi-engine/src/test/resources/openapigenerator/testCoconutSchema/assets/SchemaMasterApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testCoconutSchema/assets/SchemaMasterApi.java
@@ -1,6 +1,5 @@
 package com.sngular.multifileplugin.testCoconutSchema;
 
-import java.lang.String;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;

--- a/multiapi-engine/src/test/resources/openapigenerator/testComplexAnyOf/assets/SchemaApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testComplexAnyOf/assets/SchemaApi.java
@@ -1,6 +1,5 @@
 package com.sngular.multifileplugin.testcomplexanyof.api;
 
-import java.lang.String;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;

--- a/multiapi-engine/src/test/resources/openapigenerator/testComplexAnyOf/assets/SchemaMasterApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testComplexAnyOf/assets/SchemaMasterApi.java
@@ -1,6 +1,5 @@
 package com.sngular.multifileplugin.testcomplexanyof.api;
 
-import java.lang.String;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;

--- a/multiapi-engine/src/test/resources/openapigenerator/testQueryParam/assets/TestApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testQueryParam/assets/TestApi.java
@@ -1,6 +1,5 @@
 package com.sngular.multifileplugin.testQueryParam;
 
-import java.lang.String;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestrictionsSchema/assets/SchemaApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestrictionsSchema/assets/SchemaApi.java
@@ -1,6 +1,5 @@
 package com.sngular.multifileplugin.testRestrictionsSchema;
 
-import java.lang.String;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;

--- a/multiapi-engine/src/test/resources/openapigenerator/testRestrictionsSchema/assets/SchemaMasterApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testRestrictionsSchema/assets/SchemaMasterApi.java
@@ -1,6 +1,5 @@
 package com.sngular.multifileplugin.testRestrictionsSchema;
 
-import java.lang.String;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;

--- a/multiapi-engine/src/test/resources/openapigenerator/testSimpleBuild/assets/V1Api.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testSimpleBuild/assets/V1Api.java
@@ -1,6 +1,5 @@
 package com.sngular.multifileplugin.testsimplebuild;
 
-import java.lang.String;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.6.5'
+version = '6.6.6'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.6.5'
+  implementation 'com.sngular:multiapi-engine:6.6.6'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.5'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.6'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.6.5</version>
+    <version>6.6.6</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.6.5</version>
+      <version>6.6.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## Problem

Fixes #371. A `string`-typed operation parameter (query/path/header) generated a
spurious `import java.lang.String;` in the API interface (reported as
`java.util.String` on 6.2.1). `String` is a `java.lang` type and is implicitly
imported, so the statement is always wrong (and, as `java.util.String`, does not
even compile).

## Root cause

Parameter imports are resolved through `SchemaFieldObjectType.getImportName()` —
which has exactly one caller (`MapperPathUtil.buildParameterObject`). Its
`IMPORT_TYPE_MAPPINGS` mapped `STRING` to the fully-qualified `"java.lang.String"`,
while every other `java.lang` basic type (`Integer`, `Long`, `Boolean`, `Float`,
`Double`, …) has **no** mapping and is therefore never imported. The template's
basic-type skip-list uses simple names (`"String"`), so it never matched the
fully-qualified value and the import leaked through.

## Fix

Remove the `STRING → "java.lang.String"` entry so `String` behaves like the other
`java.lang` types (no import). Date/`BigDecimal`/collection parameters are
unaffected — they keep their `java.time.*` / `java.math.*` / `java.util.*` imports.

Updated the golden API assets that had captured the spurious import
(`testSimpleBuild`, `testQueryParam`, `testCoconutSchema`, `testComplexAnyOf`,
`testRestrictionsSchema`).

## Testing

`multiapi-engine`: **122 tests pass** (the 5 previously-affected golden-file tests
now assert the corrected output).

Version bumped to `6.6.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
