### PR TITLE
Fix #378: resolve nested external $ref inside allOf/anyOf/oneOf arrays

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.6.7</version>
+  <version>6.6.8</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ModelBuilder.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/ModelBuilder.java
@@ -739,6 +739,11 @@ public final class ModelBuilder {
         for (var fieldObject : fieldObjectArrayList) {
           fieldObject.setRequired(true);
         }
+      } else if (ApiTool.hasProperties(ref)) {
+        ApiTool.getProperties(ref).forEachRemaining(processProperties("", totalSchemas, compositedSchemas, fieldObjectArrayList, specFile, ref, antiLoopList, baseDir));
+        for (var fieldObject : fieldObjectArrayList) {
+          fieldObject.setRequired(true);
+        }
       }
     }
     return fieldObjectArrayList;

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/SchemaUtil.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/SchemaUtil.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.sngular.api.generator.plugin.openapi.exception.FileParseException;
 import org.apache.commons.lang3.StringUtils;
@@ -96,55 +97,77 @@ public class SchemaUtil {
       return;
     }
     if (node.isArray()) {
-      final ArrayNode array = (ArrayNode) node;
-      for (int i = 0; i < array.size(); i++) {
-        final JsonNode element = array.get(i);
-        if (element.isObject() && element.has("$ref")) {
-          final String refVal = element.get("$ref").textValue();
-          if (StringUtils.isNotEmpty(refVal) && !refVal.startsWith("#") && !refVal.startsWith("http") && !PathUtil.isRemoteUri(refVal)) {
-            try {
-              final URI nestedBase = resolveActualBaseUri(baseUri, refVal);
-              final JsonNode resolved = getPojoFromRef(baseUri, refVal);
-              if (Objects.nonNull(resolved)) {
-                array.set(i, resolved);
-                resolveNestedFileRefs(resolved, nestedBase);
-              }
-            } catch (final Exception ignored) {
-            }
-          } else {
-            resolveNestedFileRefs(element, baseUri);
-          }
-        } else {
+      resolveNestedFileRefsInArray((ArrayNode) node, baseUri);
+    } else if (node.isObject()) {
+      resolveNestedFileRefsInObject(node, baseUri);
+    }
+  }
+
+  private static void resolveNestedFileRefsInArray(final ArrayNode array, final URI baseUri) {
+    for (int i = 0; i < array.size(); i++) {
+      final JsonNode element = array.get(i);
+      if (element.isObject() && element.has("$ref")) {
+        final boolean resolved = resolveRefInArray(array, i, baseUri);
+        if (!resolved) {
           resolveNestedFileRefs(element, baseUri);
         }
+      } else {
+        resolveNestedFileRefs(element, baseUri);
       }
-      return;
     }
-    if (!node.isObject()) {
-      return;
-    }
+  }
+
+  private static void resolveNestedFileRefsInObject(final JsonNode node, final URI baseUri) {
     final Iterator<Entry<String, JsonNode>> fields = node.fields();
     while (fields.hasNext()) {
       final Entry<String, JsonNode> field = fields.next();
       if (field.getValue().isObject() && field.getValue().has("$ref")) {
-        final String refVal = field.getValue().get("$ref").textValue();
-        if (StringUtils.isNotEmpty(refVal) && !refVal.startsWith("#") && !refVal.startsWith("http") && !PathUtil.isRemoteUri(refVal)) {
-          try {
-            final URI nestedBase = resolveActualBaseUri(baseUri, refVal);
-            final JsonNode resolved = getPojoFromRef(baseUri, refVal);
-            if (Objects.nonNull(resolved)) {
-              field.setValue(resolved);
-              resolveNestedFileRefs(resolved, nestedBase);
-            }
-          } catch (final Exception ignored) {
-          }
-        } else {
+        final boolean resolved = resolveRefInObject((ObjectNode) node, field.getKey(), baseUri);
+        if (!resolved) {
           resolveNestedFileRefs(field.getValue(), baseUri);
         }
       } else {
         resolveNestedFileRefs(field.getValue(), baseUri);
       }
     }
+  }
+
+  private static boolean resolveRefInArray(final ArrayNode array, final int index, final URI baseUri) {
+    final JsonNode refNode = array.get(index);
+    final String refVal = refNode.get("$ref").textValue();
+    if (StringUtils.isEmpty(refVal) || refVal.startsWith("#") || refVal.startsWith("http") || PathUtil.isRemoteUri(refVal)) {
+      return false;
+    }
+    try {
+      final URI nestedBase = resolveActualBaseUri(baseUri, refVal);
+      final JsonNode resolved = getPojoFromRef(baseUri, refVal);
+      if (Objects.nonNull(resolved)) {
+        array.set(index, resolved);
+        resolveNestedFileRefs(resolved, nestedBase);
+        return true;
+      }
+    } catch (final Exception ignored) {
+    }
+    return false;
+  }
+
+  private static boolean resolveRefInObject(final ObjectNode parent, final String fieldName, final URI baseUri) {
+    final JsonNode refNode = parent.get(fieldName);
+    final String refVal = refNode.get("$ref").textValue();
+    if (StringUtils.isEmpty(refVal) || refVal.startsWith("#") || refVal.startsWith("http") || PathUtil.isRemoteUri(refVal)) {
+      return false;
+    }
+    try {
+      final URI nestedBase = resolveActualBaseUri(baseUri, refVal);
+      final JsonNode resolved = getPojoFromRef(baseUri, refVal);
+      if (Objects.nonNull(resolved)) {
+        parent.set(fieldName, resolved);
+        resolveNestedFileRefs(resolved, nestedBase);
+        return true;
+      }
+    } catch (final Exception ignored) {
+    }
+    return false;
   }
 
   static URI resolveActualBaseUriPublic(final URI rootFilePath, final String filePath) {

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/SchemaUtil.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/SchemaUtil.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.sngular.api.generator.plugin.openapi.exception.FileParseException;
 import org.apache.commons.lang3.StringUtils;
@@ -37,15 +38,12 @@ public class SchemaUtil {
         final var refValueArr = refValue.split("#");
         final var filePath = refValueArr[0];
         final URI actualFileBase = resolveActualBaseUri(rootFilePath, filePath);
-        solvedRef = getPojoFromRef(rootFilePath, filePath);
+        solvedRef = loadAndResolveRefs(rootFilePath, filePath);
         if (ApiTool.hasComponents(solvedRef)) {
           schemaMap.putAll(ApiTool.getComponentSchemas(solvedRef));
           if (refValueArr.length > 1) {
             solvedRef = solvedRef.findValue(MapperUtil.getKey(refValueArr[1]));
           }
-        }
-        if (Objects.nonNull(solvedRef) && Objects.nonNull(actualFileBase)) {
-          resolveNestedFileRefs(solvedRef, actualFileBase);
         }
       }
     } else {
@@ -93,8 +91,36 @@ public class SchemaUtil {
     }
   }
 
-  private static void resolveNestedFileRefs(final JsonNode node, final URI baseUri) {
-    if (Objects.isNull(node) || !node.isObject()) {
+  static void resolveNestedFileRefs(final JsonNode node, final URI baseUri) {
+    if (Objects.isNull(node)) {
+      return;
+    }
+    if (node.isArray()) {
+      final ArrayNode array = (ArrayNode) node;
+      for (int i = 0; i < array.size(); i++) {
+        final JsonNode element = array.get(i);
+        if (element.isObject() && element.has("$ref")) {
+          final String refVal = element.get("$ref").textValue();
+          if (StringUtils.isNotEmpty(refVal) && !refVal.startsWith("#") && !refVal.startsWith("http") && !PathUtil.isRemoteUri(refVal)) {
+            try {
+              final URI nestedBase = resolveActualBaseUri(baseUri, refVal);
+              final JsonNode resolved = getPojoFromRef(baseUri, refVal);
+              if (Objects.nonNull(resolved)) {
+                array.set(i, resolved);
+                resolveNestedFileRefs(resolved, nestedBase);
+              }
+            } catch (final Exception ignored) {
+            }
+          } else {
+            resolveNestedFileRefs(element, baseUri);
+          }
+        } else {
+          resolveNestedFileRefs(element, baseUri);
+        }
+      }
+      return;
+    }
+    if (!node.isObject()) {
       return;
     }
     final Iterator<Entry<String, JsonNode>> fields = node.fields();
@@ -102,7 +128,7 @@ public class SchemaUtil {
       final Entry<String, JsonNode> field = fields.next();
       if (field.getValue().isObject() && field.getValue().has("$ref")) {
         final String refVal = field.getValue().get("$ref").textValue();
-        if (StringUtils.isNotEmpty(refVal) && !refVal.startsWith("#") && !refVal.startsWith("http")) {
+        if (StringUtils.isNotEmpty(refVal) && !refVal.startsWith("#") && !refVal.startsWith("http") && !PathUtil.isRemoteUri(refVal)) {
           try {
             final URI nestedBase = resolveActualBaseUri(baseUri, refVal);
             final JsonNode resolved = getPojoFromRef(baseUri, refVal);
@@ -112,11 +138,17 @@ public class SchemaUtil {
             }
           } catch (final Exception ignored) {
           }
+        } else {
+          resolveNestedFileRefs(field.getValue(), baseUri);
         }
       } else {
         resolveNestedFileRefs(field.getValue(), baseUri);
       }
     }
+  }
+
+  static URI resolveActualBaseUriPublic(final URI rootFilePath, final String filePath) {
+    return resolveActualBaseUri(rootFilePath, filePath);
   }
 
   public static JsonNode getPojoFromRef(final URI rootFilePath, final String refPath) {
@@ -130,6 +162,15 @@ public class SchemaUtil {
       throw new FileParseException("empty .yml");
     }
     return schemaFile;
+  }
+
+  public static JsonNode loadAndResolveRefs(final URI rootFilePath, final String refPath) {
+    final JsonNode node = getPojoFromRef(rootFilePath, refPath);
+    final URI actualBase = resolveActualBaseUri(rootFilePath, refPath);
+    if (Objects.nonNull(actualBase)) {
+      resolveNestedFileRefs(node, actualBase);
+    }
+    return node;
   }
 
   private static String readFile(final URI rootFilePath, final String filePath) throws MalformedURLException {

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/utils/MapperPathUtil.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/utils/MapperPathUtil.java
@@ -363,7 +363,7 @@ public class MapperPathUtil {
       } else {
         try {
           final URI baseUri = baseDir.resolve(specFile.getFilePath()).getParent().toUri();
-          realResponse = SchemaUtil.getPojoFromRef(baseUri, refValue);
+          realResponse = SchemaUtil.loadAndResolveRefs(baseUri, refValue);
         } catch (final Exception e) {
           return;
         }

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -223,6 +223,13 @@ public final class OpenApiGeneratorFixtures {
 					.modelNameSuffix("DTO")
 					.useLombokModelAnnotation(true).build());
 
+	static final List<SpecFile> TEST_NESTED_REF_IN_ALLOF = List
+			.of(SpecFile.builder().filePath("openapigenerator/testNestedRefInAllOf/api-test.yml")
+					.apiPackage("com.sngular.multifileplugin.testnestedrefinallof")
+					.modelPackage("com.sngular.multifileplugin.testnestedrefinallof.model")
+					.modelNameSuffix("DTO")
+					.useLombokModelAnnotation(true).build());
+
 	static final List<SpecFile> TEST_NO_CONTENT_RESPONSES = List
 			.of(SpecFile.builder().filePath("openapigenerator/testNoContentResponses/api-test.yml")
 					.apiPackage("com.sngular.multifileplugin.testnocontentresponses")
@@ -1577,6 +1584,22 @@ public final class OpenApiGeneratorFixtures {
 
 		final List<String> expectedTestApiModelFiles = List
 				.of(COMMON_PATH + "assets/InlineResponse200ListServicesDTO.java", COMMON_PATH + "assets/Service_typeDTO.java");
+
+return path -> commonTest(path, expectedTestApiFiles, expectedTestApiModelFiles, DEFAULT_TARGET_API,
+			DEFAULT_MODEL_API, Collections.emptyList(), null);
+	}
+
+	static Function<Path, Boolean> validateNestedRefInAllOf() {
+		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/testnestedrefinallof";
+
+		final String DEFAULT_MODEL_API = "generated/com/sngular/multifileplugin/testnestedrefinallof/model";
+
+		final String COMMON_PATH = "openapigenerator/testNestedRefInAllOf/";
+
+		final List<String> expectedTestApiFiles = List.of(COMMON_PATH + "assets/ProductsApi.java");
+
+		final List<String> expectedTestApiModelFiles = List
+				.of(COMMON_PATH + "assets/InlineResponse200ListProductsDTO.java");
 
 		return path -> commonTest(path, expectedTestApiFiles, expectedTestApiModelFiles, DEFAULT_TARGET_API,
 				DEFAULT_MODEL_API, Collections.emptyList(), null);

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
@@ -107,6 +107,8 @@ class OpenApiGeneratorTest {
             OpenApiGeneratorFixtures.validateExternalPathItemRefGeneration()),
         Arguments.of("testNestedExternalRefs", OpenApiGeneratorFixtures.TEST_NESTED_EXTERNAL_REFS,
             OpenApiGeneratorFixtures.validateNestedExternalRefs()),
+        Arguments.of("testNestedRefInAllOf", OpenApiGeneratorFixtures.TEST_NESTED_REF_IN_ALLOF,
+            OpenApiGeneratorFixtures.validateNestedRefInAllOf()),
         Arguments.of("testNoContentResponses", OpenApiGeneratorFixtures.TEST_NO_CONTENT_RESPONSES,
             OpenApiGeneratorFixtures.validateNoContentResponses()),
         Arguments.of("testAnyOfInResponse", OpenApiGeneratorFixtures.TEST_ANY_OF_IN_RESPONSE,

--- a/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/api-test.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/api-test.yml
@@ -1,0 +1,23 @@
+---
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Nested Ref In AllOf Test
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:8080/v1
+paths:
+  /products:
+    get:
+      summary: List all products
+      operationId: listProducts
+      tags:
+      - products
+      responses:
+        '200':
+          description: A list of products
+          content:
+            application/json:
+              schema:
+                $ref: "schemas/Product.yml"

--- a/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/assets/InlineResponse200ListProductsDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/assets/InlineResponse200ListProductsDTO.java
@@ -1,0 +1,39 @@
+package com.sngular.multifileplugin.testnestedrefinallof.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+public class InlineResponse200ListProductsDTO {
+
+  @JsonProperty(value ="name")
+  @NonNull
+  private String name;
+
+  @JsonProperty(value ="id")
+  @NonNull
+  private String id;
+
+  @JsonProperty(value ="sku")
+  @NonNull
+  private String sku;
+
+  @JsonProperty(value ="price")
+  @NonNull
+  private Double price;
+
+
+  @Builder
+  @Jacksonized
+  private InlineResponse200ListProductsDTO(@NonNull String name, @NonNull String id, @NonNull String sku, @NonNull Double price) {
+    this.name = name;
+    this.id = id;
+    this.sku = sku;
+    this.price = price;
+
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/assets/ProductsApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/assets/ProductsApi.java
@@ -1,0 +1,46 @@
+package com.sngular.multifileplugin.testnestedrefinallof;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import com.sngular.multifileplugin.testnestedrefinallof.model.InlineResponse200ListProductsDTO;
+
+public interface ProductsApi {
+
+  /**
+   * GET /products: List all products
+   * @return  A list of products; (status code 200)
+   */
+
+  @Operation(
+    operationId = "listProducts",
+    summary = "List all products",
+    tags = {"products"},
+    responses = {
+      @ApiResponse(responseCode = "200", description = "A list of products", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InlineResponse200ListProductsDTO.class)))
+    }
+  )
+  @RequestMapping(
+    method = RequestMethod.GET,
+    value = "/products",
+    produces = {"application/json"}
+  )
+
+  default ResponseEntity<InlineResponse200ListProductsDTO> listProducts() {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/schemas/BaseProduct.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/schemas/BaseProduct.yml
@@ -1,0 +1,7 @@
+---
+type: object
+properties:
+  id:
+    type: string
+  sku:
+    type: string

--- a/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/schemas/Product.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testNestedRefInAllOf/schemas/Product.yml
@@ -1,0 +1,10 @@
+---
+allOf:
+  - $ref: './BaseProduct.yml'
+  - type: object
+    properties:
+      name:
+        type: string
+      price:
+        type: number
+        format: double

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.6.7'
+version = '6.6.8'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.6.7'
+  implementation 'com.sngular:multiapi-engine:6.6.8'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.7'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.8'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.6.7</version>
+    <version>6.6.8</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.6.7</version>
+      <version>6.6.8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## What

Fixes #378 — nested external `$ref` values inside `allOf`/`anyOf`/`oneOf` arrays were resolved against the main `openapi.yml` directory instead of the referring file's directory, causing `FileNotFoundException` in modular multi-file contracts.

## Root cause

`SchemaUtil.resolveNestedFileRefs` only walked object fields — array elements (e.g. `allOf: [{ $ref: './Base.yml' }, ...]`) were silently skipped because the method returned early for non-object nodes. Additionally, `MapperPathUtil.buildResponse` loaded external response files via `getPojoFromRef` without calling `resolveNestedFileRefs` at all.

## Changes

- **`SchemaUtil.resolveNestedFileRefs`** — now walks into JSON arrays (`allOf`, `anyOf`, `oneOf`, `items`) and resolves relative external `$ref` values against the referring file's directory. Also recurses into object fields whose `$ref` is `#`-internal or `http`-remote (previously skipped).
- **`SchemaUtil.loadAndResolveRefs`** (new public method) — loads an external file and resolves all nested refs in one call, so `MapperPathUtil.buildResponse` no longer bypasses nested-ref resolution.
- **`MapperPathUtil.buildResponse`** — uses `loadAndResolveRefs` instead of `getPojoFromRef` for external response refs.
- **`ModelBuilder.processAllOf`** — now handles inline schemas (not just `$ref` elements), so resolved allOf members contribute their properties to the generated model.
- **`SchemaUtil.solveRef`** — uses `loadAndResolveRefs` internally, simplifying the flow.

## Tests

New `testNestedRefInAllOf` fixture: a `Product.yml` schema with `allOf` containing `$ref: './BaseProduct.yml'` (external, relative). Before the fix, the nested ref was unresolved and no model was generated. After the fix, `InlineResponse200ListProductsDTO` is generated with fields from both allOf members.

`multiapi-engine` suite: **Tests run: 125, Failures: 0, Errors: 0**; `checkstyle:check` — 0 violations.

Closes #378.