### PR TITLE
Fix #373: generate model for whole-file external schema $ref

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.6.8</version>
+  <version>6.6.9</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/SchemaUtil.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/common/tools/SchemaUtil.java
@@ -58,7 +58,7 @@ public class SchemaUtil {
    * Computes a clean schema-map key from a file-based $ref value.
    * E.g. "./ServiceType.yml" -> "SCHEMAS/SERVICE_TYPE"
    */
-  static String computeFileSchemaKey(final String refValue) {
+  public static String computeFileSchemaKey(final String refValue) {
     try {
       final String[] parts = refValue.split("/");
       final String lastRaw = parts[parts.length - 1];

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/OpenApiGenerator.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/OpenApiGenerator.java
@@ -25,6 +25,7 @@ import com.sngular.api.generator.plugin.common.tools.ApiTool;
 import com.sngular.api.generator.plugin.common.tools.MapperContentUtil;
 import com.sngular.api.generator.plugin.common.tools.MapperUtil;
 import com.sngular.api.generator.plugin.common.tools.PathUtil;
+import com.sngular.api.generator.plugin.common.tools.SchemaUtil;
 import com.sngular.api.generator.plugin.exception.GeneratorTemplateException;
 import com.sngular.api.generator.plugin.openapi.exception.DuplicateModelClassException;
 import com.sngular.api.generator.plugin.openapi.model.AuthObject;
@@ -245,8 +246,22 @@ public class OpenApiGenerator {
     }
 
     if (ApiTool.hasRef(basicSchema)) {
+      final String refValue = ApiTool.getRefValue(basicSchema);
       final var refSchema = MapperUtil.getRefSchemaName(basicSchema, schemaName);
-      writeSchemaObject(specFile, refSchema, basicSchemaMap.get(refSchema), basicSchemaMap, modelPackage);
+      JsonNode resolvedSchema = basicSchemaMap.get(refSchema);
+      if (Objects.isNull(resolvedSchema) && StringUtils.isNotEmpty(refValue) && !refValue.startsWith("#")) {
+        // Whole-file external $ref (no JSON-pointer fragment): the file IS the schema.
+        // Resolve it from the filesystem so the model is generated.
+        try {
+          resolvedSchema =
+              SchemaUtil.solveRef(refValue, basicSchemaMap, this.baseDir.resolve(specFile.getFilePath()).getParent().toUri());
+        } catch (final Exception e) {
+          resolvedSchema = null;
+        }
+      }
+      if (Objects.nonNull(resolvedSchema)) {
+        writeSchemaObject(specFile, refSchema, resolvedSchema, basicSchemaMap, modelPackage);
+      }
     } else if (!ApiTool.isArray(basicSchema) && !TypeConstants.STRING.equalsIgnoreCase(ApiTool.getType(basicSchema))) {
       writeSchemaObject(specFile, schemaName, basicSchema, basicSchemaMap, modelPackage);
     }

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/utils/MapperPathUtil.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/utils/MapperPathUtil.java
@@ -451,7 +451,8 @@ public class MapperPathUtil {
       refSchema = SchemaUtil.solveRef(refValue, globalObject.getSchemaMap(),
                                       baseDir.resolve(specFile.getFilePath()).getParent().toUri());
       if (Objects.nonNull(refSchema) && !refValue.contains("#")) {
-        globalObject.getSchemaMap().put(inlinePojoName, refSchema);
+        final String key = resolveSchemaMapKey(refValue, refSchema, inlinePojoName);
+        globalObject.getSchemaMap().put(key, refSchema);
       }
     } else if (refValue.contains("requestBodies")) {
       refSchema = SchemaUtil.solveRef(refValue, globalObject.getRequestBodyMap(),
@@ -468,6 +469,17 @@ public class MapperPathUtil {
       globalObject.getSchemaMap().put(inlinePojoName, refSchema);
     }
     return refSchema;
+  }
+
+  private static String resolveSchemaMapKey(final String refValue, final JsonNode resolvedSchema, final String inlinePojoName) {
+    if (StringUtils.isNotEmpty(refValue) && !refValue.startsWith("#") && !refValue.contains("#")
+        && !StringUtils.startsWith(inlinePojoName, "Inline")
+        && Objects.nonNull(resolvedSchema) && !ApiTool.hasComponents(resolvedSchema)
+        && (ApiTool.hasType(resolvedSchema) || ApiTool.isComposed(resolvedSchema) || ApiTool.isEnum(resolvedSchema))) {
+      final String fileKey = SchemaUtil.computeFileSchemaKey(refValue);
+      return StringUtils.defaultIfEmpty(fileKey, inlinePojoName);
+    }
+    return inlinePojoName;
   }
 
   private static SchemaFieldObjectType getObjectOrType(

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -19,6 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Slf4j
 public final class OpenApiGeneratorFixtures {
 

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -230,6 +230,13 @@ public final class OpenApiGeneratorFixtures {
 					.modelNameSuffix("DTO")
 					.useLombokModelAnnotation(true).build());
 
+	static final List<SpecFile> TEST_EXTERNAL_SCHEMA_FILE_REF = List
+			.of(SpecFile.builder().filePath("openapigenerator/testExternalSchemaFileRef/api-test.yml")
+					.apiPackage("com.sngular.multifileplugin.testexternalschemafileref")
+					.modelPackage("com.sngular.multifileplugin.testexternalschemafileref.model")
+					.modelNameSuffix("DTO")
+					.useLombokModelAnnotation(true).build());
+
 	static final List<SpecFile> TEST_ANY_OF_IN_RESPONSE = List
 			.of(SpecFile.builder().filePath("openapigenerator/testAnyOfInResponse/api-test.yml")
 					.apiPackage("com.sngular.multifileplugin.testanyofinresponse")
@@ -1595,6 +1602,32 @@ public final class OpenApiGeneratorFixtures {
 
 		return path -> commonTest(path, expectedTestApiFiles, expectedTestApiModelFiles, DEFAULT_TARGET_API,
 				DEFAULT_MODEL_API, Collections.emptyList(), null);
+	}
+
+	static Function<Path, Boolean> validateExternalSchemaFileRef() {
+		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/testexternalschemafileref";
+		final String DEFAULT_MODEL_API = "generated/com/sngular/multifileplugin/testexternalschemafileref/model";
+		final String COMMON_PATH = "openapigenerator/testExternalSchemaFileRef/";
+		final List<String> expectedTestApiFiles = List.of(COMMON_PATH + "assets/DashboardApi.java", COMMON_PATH + "assets/SummaryApi.java");
+		final List<String> expectedTestApiModelFiles = List
+				.of(COMMON_PATH + "assets/DashboardDTO.java", COMMON_PATH + "assets/SummaryDTO.java");
+		return path -> commonTest(path, expectedTestApiFiles, expectedTestApiModelFiles, DEFAULT_TARGET_API,
+				DEFAULT_MODEL_API, Collections.emptyList(), null);
+	}
+
+	static Function<Path, Boolean> validateExternalSchemaFileRefDebug() {
+		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/testexternalschemafileref";
+		final String DEFAULT_MODEL_API = "generated/com/sngular/multifileplugin/testexternalschemafileref/model";
+		return path -> {
+			final Path modelPath = path.resolve("target").resolve(DEFAULT_MODEL_API);
+			final var files = modelPath.toFile().listFiles();
+			if (files != null) {
+				for (final var f : files) {
+					System.out.println("GENERATED MODEL: " + f.getName());
+				}
+			}
+			return true;
+		};
 	}
 
 	private static Boolean commonTest(final Path resultPath, final List<String> expectedFile,

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -19,8 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @Slf4j
 public final class OpenApiGeneratorFixtures {
 
@@ -1636,21 +1634,6 @@ return path -> commonTest(path, expectedTestApiFiles, expectedTestApiModelFiles,
 				.of(COMMON_PATH + "assets/DashboardDTO.java", COMMON_PATH + "assets/SummaryDTO.java");
 		return path -> commonTest(path, expectedTestApiFiles, expectedTestApiModelFiles, DEFAULT_TARGET_API,
 				DEFAULT_MODEL_API, Collections.emptyList(), null);
-	}
-
-	static Function<Path, Boolean> validateExternalSchemaFileRefDebug() {
-		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/testexternalschemafileref";
-		final String DEFAULT_MODEL_API = "generated/com/sngular/multifileplugin/testexternalschemafileref/model";
-		return path -> {
-			final Path modelPath = path.resolve("target").resolve(DEFAULT_MODEL_API);
-			final var files = modelPath.toFile().listFiles();
-			if (files != null) {
-				for (final var f : files) {
-					System.out.println("GENERATED MODEL: " + f.getName());
-				}
-			}
-			return true;
-		};
 	}
 
 	private static Boolean commonTest(final Path resultPath, final List<String> expectedFile,

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
@@ -109,6 +109,8 @@ class OpenApiGeneratorTest {
             OpenApiGeneratorFixtures.validateNestedExternalRefs()),
         Arguments.of("testNoContentResponses", OpenApiGeneratorFixtures.TEST_NO_CONTENT_RESPONSES,
             OpenApiGeneratorFixtures.validateNoContentResponses()),
+        Arguments.of("testExternalSchemaFileRef", OpenApiGeneratorFixtures.TEST_EXTERNAL_SCHEMA_FILE_REF,
+            OpenApiGeneratorFixtures.validateExternalSchemaFileRef()),
         Arguments.of("testAnyOfInResponse", OpenApiGeneratorFixtures.TEST_ANY_OF_IN_RESPONSE,
             OpenApiGeneratorFixtures.validateAnyOfInResponse()),
         Arguments.of("testOneOfInResponse", OpenApiGeneratorFixtures.TEST_ONE_OF_IN_RESPONSE,

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/api-test.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/api-test.yml
@@ -1,0 +1,44 @@
+---
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: External Schema File Ref Test
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:8080/v1
+paths:
+  /dashboard:
+    get:
+      summary: Get dashboard
+      operationId: getDashboard
+      tags:
+      - dashboard
+      responses:
+        '200':
+          description: Dashboard data
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Dashboard"
+  /summary:
+    get:
+      summary: Get summary
+      operationId: getSummary
+      tags:
+      - summary
+      responses:
+        '200':
+          description: Summary data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Summary"
+components:
+  schemas:
+    Dashboard:
+      $ref: "schemas/Dashboard.yml"
+    Summary:
+      $ref: "schemas/Summary.yml"

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/assets/DashboardApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/assets/DashboardApi.java
@@ -1,0 +1,46 @@
+package com.sngular.multifileplugin.testexternalschemafileref;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import com.sngular.multifileplugin.testexternalschemafileref.model.DashboardDTO;
+
+public interface DashboardApi {
+
+  /**
+   * GET /dashboard: Get dashboard
+   * @return  Dashboard data; (status code 200)
+   */
+
+  @Operation(
+    operationId = "getDashboard",
+    summary = "Get dashboard",
+    tags = {"dashboard"},
+    responses = {
+      @ApiResponse(responseCode = "200", description = "Dashboard data", content = @Content(mediaType = "application/json", schema = @Schema(implementation = List.class)))
+    }
+  )
+  @RequestMapping(
+    method = RequestMethod.GET,
+    value = "/dashboard",
+    produces = {"application/json"}
+  )
+
+  default ResponseEntity<List<DashboardDTO>> getDashboard() {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/assets/DashboardDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/assets/DashboardDTO.java
@@ -1,0 +1,26 @@
+package com.sngular.multifileplugin.testexternalschemafileref.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+public class DashboardDTO {
+
+  @JsonProperty(value ="id")
+  private String id;
+
+  @JsonProperty(value ="title")
+  private String title;
+
+
+  @Builder
+  @Jacksonized
+  private DashboardDTO(String id, String title) {
+    this.id = id;
+    this.title = title;
+
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/assets/SummaryApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/assets/SummaryApi.java
@@ -1,0 +1,46 @@
+package com.sngular.multifileplugin.testexternalschemafileref;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import com.sngular.multifileplugin.testexternalschemafileref.model.SummaryDTO;
+
+public interface SummaryApi {
+
+  /**
+   * GET /summary: Get summary
+   * @return  Summary data; (status code 200)
+   */
+
+  @Operation(
+    operationId = "getSummary",
+    summary = "Get summary",
+    tags = {"summary"},
+    responses = {
+      @ApiResponse(responseCode = "200", description = "Summary data", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SummaryDTO.class)))
+    }
+  )
+  @RequestMapping(
+    method = RequestMethod.GET,
+    value = "/summary",
+    produces = {"application/json"}
+  )
+
+  default ResponseEntity<SummaryDTO> getSummary() {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/assets/SummaryDTO.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/assets/SummaryDTO.java
@@ -1,0 +1,26 @@
+package com.sngular.multifileplugin.testexternalschemafileref.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+public class SummaryDTO {
+
+  @JsonProperty(value ="total")
+  private Integer total;
+
+  @JsonProperty(value ="active")
+  private Boolean active;
+
+
+  @Builder
+  @Jacksonized
+  private SummaryDTO(Integer total, Boolean active) {
+    this.total = total;
+    this.active = active;
+
+  }
+
+}

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/schemas/Dashboard.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/schemas/Dashboard.yml
@@ -1,0 +1,7 @@
+---
+type: object
+properties:
+  id:
+    type: string
+  title:
+    type: string

--- a/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/schemas/Summary.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testExternalSchemaFileRef/schemas/Summary.yml
@@ -1,0 +1,8 @@
+---
+type: object
+properties:
+  total:
+    type: integer
+    format: int32
+  active:
+    type: boolean

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.6.8'
+version = '6.6.9'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.6.8'
+  implementation 'com.sngular:multiapi-engine:6.6.9'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.8'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.6.9'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.6.8</version>
+    <version>6.6.9</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.6.8</version>
+      <version>6.6.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## What

Fixes #373 — when a schema is referenced as a **whole external file** (no JSON-pointer fragment, the file *is* the schema), the model was never generated. The API interface was produced importing a DTO that was never emitted, so the generated code did not compile.

This is the modular-contract style produced by tools like `redocly split`:
```yaml
components:
  schemas:
    Dashboard:
      $ref: "./schemas/Dashboard.yml"   # whole file is the schema
```
```yaml
# schemas/Dashboard.yml  (the file IS the schema object)
type: object
properties:
  id: { type: string }
```

**Depends on #400 (PR for #378)**. Please merge #400 first, then rebase this PR on the updated main.

## Root cause

- `OpenApiGenerator.processModel` only resolved `$ref` via the schema-map key. For whole-file external refs, the map key (`SCHEMAS/X`) never matched the file-path ref, so `basicSchemaMap.get(refSchema)` returned null and no model was written.
- `MapperPathUtil.getRefSchema` registered the resolved schema under the inline pojo name for response/request refs, but component refs to whole-file schemas were never registered at all.

## Changes

- **`OpenApiGenerator.processModel`**: when a component schema is a whole-file external `$ref` (ref value does not start with `#`), resolve it from the filesystem via `SchemaUtil.solveRef` and generate the model.
- **`MapperPathUtil.getRefSchema`** (new `resolveSchemaMapKey` helper): when the resolved schema is a whole-file schema (no `components` wrapper, has `type`/is composed/is enum) and the inline pojo name suggests a component (not an `Inline*` response name), register it in the schema map under a `SCHEMAS/X`-style key so `processModels` emits it without duplicating the model already created for a response/request ref.
- **`SchemaUtil.computeFileSchemaKey`**: made public for cross-package use.

## Tests

New `testExternalSchemaFileRef` fixture: two component schemas (`Dashboard`, `Summary`) that `$ref` whole external files, each used in a response. Both `DashboardDTO` and `SummaryDTO` are correctly generated.

`multiapi-engine` suite: **Tests run: 125, Failures: 0, Errors: 0**; `checkstyle:check` — 0 violations.

Closes #373.