### PR TITLE
Fix #407: preserve path-level parameters when grouping by tags

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-<version>6.7.0</version>
+  <version>6.7.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/utils/OpenApiUtil.java
+++ b/multiapi-engine/src/main/java/com/sngular/api/generator/plugin/openapi/utils/OpenApiUtil.java
@@ -83,10 +83,21 @@ public class OpenApiUtil {
       final var method = operations.next();
       if (ApiTool.hasNode(method.getValue(), "tags")) {
         final var tag = ApiTool.getNode(method.getValue(), "tags").elements().next().asText();
-        mapByTag.put(tag, Map.of(pathItem.getKey(), new ObjectNode(JsonNodeFactory.instance, Map.ofEntries(method))));
+        mapByTag.put(tag, Map.of(pathItem.getKey(), buildTaggedPathItem(pathItem.getValue(), method)));
       }
     }
     return mapByTag;
+  }
+
+  private static ObjectNode buildTaggedPathItem(final JsonNode pathItem, final Entry<String, JsonNode> method) {
+    final var taggedPathItem = JsonNodeFactory.instance.objectNode();
+    taggedPathItem.set(method.getKey(), method.getValue());
+    pathItem.fields().forEachRemaining(field -> {
+      if (!REST_VERB_SET.contains(field.getKey()) && !taggedPathItem.has(field.getKey())) {
+        taggedPathItem.set(field.getKey(), field.getValue());
+      }
+    });
+    return taggedPathItem;
   }
 
   public static JsonNode getPojoFromSpecFile(final Path baseDir, final SpecFile specFile) {

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -119,6 +119,12 @@ public final class OpenApiGeneratorFixtures {
 					.modelPackage("com.sngular.multifileplugin.pathparameter.model").modelNameSuffix("DTO")
 					.useLombokModelAnnotation(false).build());
 
+	static final List<SpecFile> TEST_PATH_LEVEL_INLINE_PARAMETER_GENERATION = List
+			.of(SpecFile.builder().filePath("openapigenerator/testPathLevelInlineParameter/api-test.yml")
+					.apiPackage("com.sngular.multifileplugin.pathlevelinlineparameter")
+					.modelPackage("com.sngular.multifileplugin.pathlevelinlineparameter.model").modelNameSuffix("DTO")
+					.useTagsGroup(true).useLombokModelAnnotation(false).build());
+
 	static final List<SpecFile> TEST_WEB_CLIENT_GENERATION = List
 			.of(SpecFile.builder().filePath("openapigenerator/testWebClientApiGeneration/api-test.yml")
 					.apiPackage("com.sngular.multifileplugin.webclientapi")
@@ -779,6 +785,25 @@ public final class OpenApiGeneratorFixtures {
 
 		final List<String> expectedTestApiModelFiles = List.of(ASSETS_PATH + "ErrorDTO.java",
 				ASSETS_PATH + "TestDTO.java", ASSETS_PATH + "TestInfoDTO.java");
+
+		return path -> commonTest(path, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API,
+				DEFAULT_MODEL_API, Collections.emptyList(), null);
+
+	}
+
+	static Function<Path, Boolean> validatePathLevelInlineParameterGeneration() {
+
+		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/pathlevelinlineparameter";
+
+		final String DEFAULT_MODEL_API = "generated/com/sngular/multifileplugin/pathlevelinlineparameter/model";
+
+		final String COMMON_PATH = "openapigenerator/testPathLevelInlineParameter/";
+
+		final String ASSETS_PATH = COMMON_PATH + "assets/";
+
+		final List<String> expectedTestApiFile = List.of(ASSETS_PATH + "RolesApi.java");
+
+		final List<String> expectedTestApiModelFiles = List.of();
 
 		return path -> commonTest(path, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API,
 				DEFAULT_MODEL_API, Collections.emptyList(), null);

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
@@ -77,6 +77,8 @@ class OpenApiGeneratorTest {
             OpenApiGeneratorFixtures.validateMultipleRefGeneration()),
         Arguments.of("testApiPathParameterGeneration", OpenApiGeneratorFixtures.TEST_PATH_PARAMETER_GENERATION,
             OpenApiGeneratorFixtures.validatePathParameterGeneration()),
+        Arguments.of("testPathLevelInlineParameterGeneration", OpenApiGeneratorFixtures.TEST_PATH_LEVEL_INLINE_PARAMETER_GENERATION,
+            OpenApiGeneratorFixtures.validatePathLevelInlineParameterGeneration()),
         Arguments.of("testWebClientApiGeneration", OpenApiGeneratorFixtures.TEST_WEB_CLIENT_GENERATION,
             OpenApiGeneratorFixtures.validateWebClientGeneration()),
         Arguments.of("testClientPackageWebClientApiGeneration", OpenApiGeneratorFixtures.TEST_CLIENT_PACKAGE_WEB_CLIENT_GENERATION,

--- a/multiapi-engine/src/test/resources/openapigenerator/testPathLevelInlineParameter/api-test.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testPathLevelInlineParameter/api-test.yml
@@ -1,0 +1,37 @@
+---
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Path Level Parameter Test Api
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:8080/v1
+paths:
+  /roles/{roleId}:
+    parameters:
+      - name: roleId
+        in: path
+        required: true
+        description: The id of the role to retrieve
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get a role by id
+      operationId: getRole
+      tags:
+      - roles
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                type: string

--- a/multiapi-engine/src/test/resources/openapigenerator/testPathLevelInlineParameter/assets/RolesApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testPathLevelInlineParameter/assets/RolesApi.java
@@ -1,0 +1,47 @@
+package com.sngular.multifileplugin.pathlevelinlineparameter;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.NativeWebRequest;
+
+
+public interface RolesApi {
+
+  /**
+   * GET /roles/{roleId}: Get a role by id
+   * @param roleId The id of the role to retrieve true
+   * @return  Expected response to a valid request; (status code 200)
+   */
+
+  @Operation(
+    operationId = "getRole",
+    summary = "Get a role by id",
+    tags = {"roles"},
+    responses = {
+      @ApiResponse(responseCode = "200", description = "Expected response to a valid request", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+      @ApiResponse(responseCode = "default", description = "unexpected error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)))
+    }
+  )
+  @RequestMapping(
+    method = RequestMethod.GET,
+    value = "/roles/{roleId}",
+    produces = {"application/json"}
+  )
+
+  default ResponseEntity<String> getRole(@Parameter(name = "roleId", description = "The id of the role to retrieve", required = true, schema = @Schema(description = "")) @PathVariable("roleId") String roleId) {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+}

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.7.0'
+version = '6.7.1'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.7.0'
+  implementation 'com.sngular:multiapi-engine:6.7.1'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-implementation 'com.sngular:scs-multiapi-gradle-plugin:6.7.0'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.7.1'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-<version>6.7.0</version>
+    <version>6.7.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-<version>6.7.0</version>
+      <version>6.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Closes #407

## What

When grouping operations by tag (`useTagsGroup = true`), path-level parameters were silently dropped from the generated method signatures.

The root cause is in `OpenApiUtil.getMapMethodsByTag`: it built a fresh `ObjectNode` containing **only the HTTP verb**, discarding the path-level `parameters` (and `summary`/`description`) declared on the Path Item. The default by-URL grouping already preserved them (which is why the bug only appeared with tag grouping).

```yaml
paths:
  /roles/{roleId}:        # path-level parameters
    parameters:
      - name: roleId
        in: path
        required: true
        schema: { type: string, format: uuid }
    get:
      operationId: getRole
      ...
```

**Before:** `default ResponseEntity<String> getRole() { ... }`
**After:** `default ResponseEntity<String> getRole(@Parameter(name = "roleId", ...) @PathVariable("roleId") String roleId) { ... }`

## Changes

- `OpenApiUtil`: new `buildTaggedPathItem` helper builds the tag-grouped Path Item by starting from the single verb and then re-attaching the non-verb fields (`parameters`, `summary`, `description`, …) from the original Path Item, so `MapperPathUtil.mapOperationObject` merges them into every operation as it already does for the by-URL path.
- Version bumped to **6.7.1** in all three modules (engine, Maven plugin, Gradle plugin).

## Tests

New end-to-end fixture `testPathLevelInlineParameterGeneration` reproduces the exact issue layout (inline path-level parameter + `useTagsGroup(true)`) and asserts the generated `RolesApi.java` contains the `@PathVariable` parameter.

## Validation

- `multiapi-engine`: full suite green (**131 tests, 0 failures**), `checkstyle:check` — 0 violations.
- `scs-multiapi-maven-plugin`: `mvn verify` green (6 integration tests, incl. `OpenApiGenerationIT`).