### PR TITLE
Add regression tests for already-fixed issues #251 and #277

### DIFF
--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.7.1</version>
+  <version>6.7.2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/v2/AsyncApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/v2/AsyncApiGeneratorFixtures.java
@@ -145,6 +145,25 @@ public class AsyncApiGeneratorFixtures {
           .build()
   );
 
+  static final List<SpecFile> TEST_CUSTOM_VALIDATORS_DIFFERENT_PACKAGES = List.of(
+      SpecFile
+          .builder()
+          .filePath("asyncapigenerator/v2/testCustomValidatorsDifferentPackages/event-api.yml")
+          .consumer(OperationParameterObject.builder()
+              .ids("customValidatorResponse")
+              .modelNameSuffix("DTO")
+              .apiPackage("com.sngular.scsplugin.customvalidatordiff.model.event.consumer")
+              .modelPackage("com.sngular.scsplugin.customvalidatordiff.model.event.consumer")
+              .build())
+          .supplier(OperationParameterObject.builder()
+              .ids("customValidatorClients")
+              .modelNameSuffix("DTO")
+              .apiPackage("com.sngular.scsplugin.customvalidatordiff.model.event.producer")
+              .modelPackage("com.sngular.scsplugin.customvalidatordiff.model.event.producer")
+              .build())
+          .build()
+  );
+
   static final List<SpecFile> TEST_FILE_GENERATION_ISSUE = List.of(
       SpecFile
           .builder()
@@ -733,6 +752,67 @@ public class AsyncApiGeneratorFixtures {
         expectedExceptionFiles, DEFAULT_EXCEPTION_API) &&
         modelTest(path, expectedModelSchemaFiles, DEFAULT_MODEL_SCHEMA_FOLDER) &&
         customValidatorTest(path, expectedValidatorFiles, DEFAULT_CUSTOM_VALIDATOR_FOLDER);
+  }
+
+  static Function<Path, Boolean> validateCustomValidatorsDifferentPackages() {
+    final String DEFAULT_CONSUMER_MODEL_FOLDER = "generated/com/sngular/scsplugin/customvalidatordiff/model/event/consumer";
+
+    final String DEFAULT_PRODUCER_MODEL_FOLDER = "generated/com/sngular/scsplugin/customvalidatordiff/model/event/producer";
+
+    final String COMMON_PATH = "asyncapigenerator/v2/testCustomValidatorsDifferentPackages/";
+
+    final List<String> expectedValidatorFiles = List.of(
+        COMMON_PATH + "assets/customvalidator/MaxBigDecimal.java",
+        COMMON_PATH + "assets/customvalidator/MaxBigDecimalValidator.java",
+        COMMON_PATH + "assets/customvalidator/MaxDouble.java",
+        COMMON_PATH + "assets/customvalidator/MaxDoubleValidator.java",
+        COMMON_PATH + "assets/customvalidator/MaxFloat.java",
+        COMMON_PATH + "assets/customvalidator/MaxFloatValidator.java",
+        COMMON_PATH + "assets/customvalidator/MaxInteger.java",
+        COMMON_PATH + "assets/customvalidator/MaxIntegerValidator.java",
+        COMMON_PATH + "assets/customvalidator/MinBigDecimal.java",
+        COMMON_PATH + "assets/customvalidator/MinBigDecimalValidator.java",
+        COMMON_PATH + "assets/customvalidator/MinDouble.java",
+        COMMON_PATH + "assets/customvalidator/MinDoubleValidator.java",
+        COMMON_PATH + "assets/customvalidator/MinFloat.java",
+        COMMON_PATH + "assets/customvalidator/MinFloatValidator.java",
+        COMMON_PATH + "assets/customvalidator/MinInteger.java",
+        COMMON_PATH + "assets/customvalidator/MinIntegerValidator.java",
+        COMMON_PATH + "assets/customvalidator/NotNull.java",
+        COMMON_PATH + "assets/customvalidator/NotNullValidator.java",
+        COMMON_PATH + "assets/customvalidator/Pattern.java",
+        COMMON_PATH + "assets/customvalidator/PatternValidator.java",
+        COMMON_PATH + "assets/customvalidator/Size.java",
+        COMMON_PATH + "assets/customvalidator/SizeValidator.java"
+    );
+
+    final List<String> expectedProducerValidatorFiles = List.of(
+        COMMON_PATH + "assets/customvalidator_producer/MaxBigDecimal.java",
+        COMMON_PATH + "assets/customvalidator_producer/MaxBigDecimalValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/MaxDouble.java",
+        COMMON_PATH + "assets/customvalidator_producer/MaxDoubleValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/MaxFloat.java",
+        COMMON_PATH + "assets/customvalidator_producer/MaxFloatValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/MaxInteger.java",
+        COMMON_PATH + "assets/customvalidator_producer/MaxIntegerValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/MinBigDecimal.java",
+        COMMON_PATH + "assets/customvalidator_producer/MinBigDecimalValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/MinDouble.java",
+        COMMON_PATH + "assets/customvalidator_producer/MinDoubleValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/MinFloat.java",
+        COMMON_PATH + "assets/customvalidator_producer/MinFloatValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/MinInteger.java",
+        COMMON_PATH + "assets/customvalidator_producer/MinIntegerValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/NotNull.java",
+        COMMON_PATH + "assets/customvalidator_producer/NotNullValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/Pattern.java",
+        COMMON_PATH + "assets/customvalidator_producer/PatternValidator.java",
+        COMMON_PATH + "assets/customvalidator_producer/Size.java",
+        COMMON_PATH + "assets/customvalidator_producer/SizeValidator.java"
+    );
+
+    return path -> customValidatorTest(path, expectedValidatorFiles, DEFAULT_CONSUMER_MODEL_FOLDER + "/customvalidator") &&
+        customValidatorTest(path, expectedProducerValidatorFiles, DEFAULT_PRODUCER_MODEL_FOLDER + "/customvalidator");
   }
 
   private static String calculateJavaEEPackage(final int springBootVersion) {

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/v2/AsyncApiGeneratorTest.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/asyncapi/v2/AsyncApiGeneratorTest.java
@@ -68,6 +68,8 @@ class AsyncApiGeneratorTest {
         Arguments.of("TestIssueInfiniteLoop", AsyncApiGeneratorFixtures.TEST_ISSUE_INFINITE_LOOP,
             AsyncApiGeneratorFixtures.validateTestIssueInfiniteLoop()),
         Arguments.of("TestCustomValidators", AsyncApiGeneratorFixtures.TEST_CUSTOM_VALIDATORS, AsyncApiGeneratorFixtures.validateCustomValidators(SPRING_BOOT_VERSION)),
+        Arguments.of("TestCustomValidatorsDifferentPackages", AsyncApiGeneratorFixtures.TEST_CUSTOM_VALIDATORS_DIFFERENT_PACKAGES,
+            AsyncApiGeneratorFixtures.validateCustomValidatorsDifferentPackages()),
         Arguments.of("TestModelClassExceptionGeneration", AsyncApiGeneratorFixtures.TEST_MODEL_CLASS_EXCEPTION_GENERATION,
             AsyncApiGeneratorFixtures.validateTestModelClassExceptionGeneration()),
         Arguments.of("TestNoSchemas", AsyncApiGeneratorFixtures.TEST_NO_SCHEMAS, AsyncApiGeneratorFixtures.validateNoSchemas()),

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorFixtures.java
@@ -125,6 +125,12 @@ public final class OpenApiGeneratorFixtures {
 					.modelPackage("com.sngular.multifileplugin.pathlevelinlineparameter.model").modelNameSuffix("DTO")
 					.useTagsGroup(true).useLombokModelAnnotation(false).build());
 
+	static final List<SpecFile> TEST_NO_DESCRIPTION_REF_PARAMETER = List
+			.of(SpecFile.builder().filePath("openapigenerator/testNoDescriptionRefParameter/api-test.yml")
+					.apiPackage("com.sngular.multifileplugin.nodescriptionrefparameter")
+					.modelPackage("com.sngular.multifileplugin.nodescriptionrefparameter.model").modelNameSuffix("DTO")
+					.useLombokModelAnnotation(false).build());
+
 	static final List<SpecFile> TEST_WEB_CLIENT_GENERATION = List
 			.of(SpecFile.builder().filePath("openapigenerator/testWebClientApiGeneration/api-test.yml")
 					.apiPackage("com.sngular.multifileplugin.webclientapi")
@@ -802,6 +808,25 @@ public final class OpenApiGeneratorFixtures {
 		final String ASSETS_PATH = COMMON_PATH + "assets/";
 
 		final List<String> expectedTestApiFile = List.of(ASSETS_PATH + "RolesApi.java");
+
+		final List<String> expectedTestApiModelFiles = List.of();
+
+		return path -> commonTest(path, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API,
+				DEFAULT_MODEL_API, Collections.emptyList(), null);
+
+	}
+
+	static Function<Path, Boolean> validateNoDescriptionRefParameterGeneration() {
+
+		final String DEFAULT_TARGET_API = "generated/com/sngular/multifileplugin/nodescriptionrefparameter";
+
+		final String DEFAULT_MODEL_API = "generated/com/sngular/multifileplugin/nodescriptionrefparameter/model";
+
+		final String COMMON_PATH = "openapigenerator/testNoDescriptionRefParameter/";
+
+		final String ASSETS_PATH = COMMON_PATH + "assets/";
+
+		final List<String> expectedTestApiFile = List.of(ASSETS_PATH + "TestApi.java");
 
 		final List<String> expectedTestApiModelFiles = List.of();
 

--- a/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
+++ b/multiapi-engine/src/test/java/com/sngular/api/generator/plugin/openapi/OpenApiGeneratorTest.java
@@ -79,6 +79,8 @@ class OpenApiGeneratorTest {
             OpenApiGeneratorFixtures.validatePathParameterGeneration()),
         Arguments.of("testPathLevelInlineParameterGeneration", OpenApiGeneratorFixtures.TEST_PATH_LEVEL_INLINE_PARAMETER_GENERATION,
             OpenApiGeneratorFixtures.validatePathLevelInlineParameterGeneration()),
+        Arguments.of("testNoDescriptionRefParameterGeneration", OpenApiGeneratorFixtures.TEST_NO_DESCRIPTION_REF_PARAMETER,
+            OpenApiGeneratorFixtures.validateNoDescriptionRefParameterGeneration()),
         Arguments.of("testWebClientApiGeneration", OpenApiGeneratorFixtures.TEST_WEB_CLIENT_GENERATION,
             OpenApiGeneratorFixtures.validateWebClientGeneration()),
         Arguments.of("testClientPackageWebClientApiGeneration", OpenApiGeneratorFixtures.TEST_CLIENT_PACKAGE_WEB_CLIENT_GENERATION,

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxBigDecimal.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxBigDecimal.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MaxBigDecimalValidator.class)
+@Documented
+public @interface MaxBigDecimal {
+    String maximum();
+    boolean exclusive();
+    String message() default "Value is bigger than the maximum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxBigDecimalValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxBigDecimalValidator.java
@@ -1,0 +1,25 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MaxBigDecimalValidator implements ConstraintValidator<MaxBigDecimal, BigDecimal> {
+
+    private BigDecimal maximum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MaxBigDecimal constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.maximum = new BigDecimal(constraintAnnotation.maximum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(BigDecimal value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.compareTo(this.maximum) < 0 || (!exclusive && value.compareTo(this.maximum) == 0));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxDouble.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxDouble.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MaxDoubleValidator.class)
+@Documented
+public @interface MaxDouble {
+    String maximum();
+    boolean exclusive();
+    String message() default "Value is bigger than the maximum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxDoubleValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxDoubleValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MaxDoubleValidator implements ConstraintValidator<MaxDouble, Double> {
+
+    private double maximum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MaxDouble constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.maximum = Double.parseDouble(constraintAnnotation.maximum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Double value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.doubleValue() < this.maximum || (!exclusive && value.doubleValue() == this.maximum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxFloat.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxFloat.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MaxFloatValidator.class)
+@Documented
+public @interface MaxFloat {
+    String maximum();
+    boolean exclusive();
+    String message() default "Value is bigger than the maximum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxFloatValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxFloatValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MaxFloatValidator implements ConstraintValidator<MaxFloat, Float> {
+
+    private float maximum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MaxFloat constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.maximum = Float.parseFloat(constraintAnnotation.maximum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Float value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.floatValue() < this.maximum || (!exclusive && value.floatValue() == this.maximum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxInteger.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxInteger.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MaxIntegerValidator.class)
+@Documented
+public @interface MaxInteger {
+    String maximum();
+    boolean exclusive();
+    String message() default "Value is bigger than the maximum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxIntegerValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MaxIntegerValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MaxIntegerValidator implements ConstraintValidator<MaxInteger, Integer> {
+
+    private int maximum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MaxInteger constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.maximum = Integer.parseInt(constraintAnnotation.maximum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.intValue() < this.maximum || (!exclusive && value.intValue() == this.maximum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinBigDecimal.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinBigDecimal.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinBigDecimalValidator.class)
+@Documented
+public @interface MinBigDecimal {
+    String minimum();
+    boolean exclusive();
+    String message() default "Value is smaller than the minimum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinBigDecimalValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinBigDecimalValidator.java
@@ -1,0 +1,25 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MinBigDecimalValidator implements ConstraintValidator<MinBigDecimal, BigDecimal> {
+
+    private BigDecimal minimum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MinBigDecimal constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.minimum = new BigDecimal(constraintAnnotation.minimum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(BigDecimal value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.compareTo(this.minimum) > 0 || (!exclusive && value.compareTo(this.minimum) == 0));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinDouble.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinDouble.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinDoubleValidator.class)
+@Documented
+public @interface MinDouble {
+    String minimum();
+    boolean exclusive();
+    String message() default "Value is smaller than the minimum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinDoubleValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinDoubleValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MinDoubleValidator implements ConstraintValidator<MinDouble, Double> {
+
+    private double minimum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MinDouble constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.minimum = Double.parseDouble(constraintAnnotation.minimum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Double value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.doubleValue() > this.minimum || (!exclusive && value.doubleValue() == this.minimum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinFloat.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinFloat.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinFloatValidator.class)
+@Documented
+public @interface MinFloat {
+    String minimum();
+    boolean exclusive();
+    String message() default "Value is smaller than the minimum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinFloatValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinFloatValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MinFloatValidator implements ConstraintValidator<MinFloat, Float> {
+
+    private float minimum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MinFloat constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.minimum = Float.parseFloat(constraintAnnotation.minimum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Float value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.floatValue() > this.minimum || (!exclusive && value.floatValue() == this.minimum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinInteger.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinInteger.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinIntegerValidator.class)
+@Documented
+public @interface MinInteger {
+    String minimum();
+    boolean exclusive();
+    String message() default "Value is smaller than the minimum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinIntegerValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/MinIntegerValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MinIntegerValidator implements ConstraintValidator<MinInteger, Integer> {
+
+    private int minimum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MinInteger constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.minimum = Integer.parseInt(constraintAnnotation.minimum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.intValue() > this.minimum || (!exclusive && value.intValue() == this.minimum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/NotNull.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/NotNull.java
@@ -1,0 +1,18 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NotNullValidator.class)
+@Documented
+public @interface NotNull {
+
+    String message() default "Value is null.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/NotNullValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/NotNullValidator.java
@@ -1,0 +1,18 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Objects;
+
+public class NotNullValidator implements ConstraintValidator<NotNull, Object> {
+
+    @Override
+    public void initialize(NotNull constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        return Objects.nonNull(value);
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/Pattern.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/Pattern.java
@@ -1,0 +1,22 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PatternValidator.class)
+@Documented
+public @interface Pattern {
+
+  String regex();
+
+  String message() default "Value does not fulfill the pattern.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/PatternValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/PatternValidator.java
@@ -1,0 +1,22 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class PatternValidator implements ConstraintValidator<Pattern, String> {
+
+  private String regex;
+
+  @Override
+  public void initialize(Pattern constraintAnnotation) {
+    ConstraintValidator.super.initialize(constraintAnnotation);
+    this.regex = constraintAnnotation.regex();
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+    return Objects.isNull(value) || value.matches(regex);
+  }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/Size.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/Size.java
@@ -1,0 +1,23 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SizeValidator.class)
+@Documented
+public @interface Size {
+
+    int min();
+
+    int max();
+
+    String message() default "Value is not between the correct values.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/SizeValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator/SizeValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.consumer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class SizeValidator implements ConstraintValidator<Size, String> {
+
+    private int min;
+    private int max;
+
+    @Override
+    public void initialize(Size constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || ((max == 0 || value.length() <= max) && (min == 0 || value.length() >= min));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxBigDecimal.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxBigDecimal.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MaxBigDecimalValidator.class)
+@Documented
+public @interface MaxBigDecimal {
+    String maximum();
+    boolean exclusive();
+    String message() default "Value is bigger than the maximum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxBigDecimalValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxBigDecimalValidator.java
@@ -1,0 +1,25 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MaxBigDecimalValidator implements ConstraintValidator<MaxBigDecimal, BigDecimal> {
+
+    private BigDecimal maximum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MaxBigDecimal constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.maximum = new BigDecimal(constraintAnnotation.maximum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(BigDecimal value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.compareTo(this.maximum) < 0 || (!exclusive && value.compareTo(this.maximum) == 0));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxDouble.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxDouble.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MaxDoubleValidator.class)
+@Documented
+public @interface MaxDouble {
+    String maximum();
+    boolean exclusive();
+    String message() default "Value is bigger than the maximum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxDoubleValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxDoubleValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MaxDoubleValidator implements ConstraintValidator<MaxDouble, Double> {
+
+    private double maximum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MaxDouble constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.maximum = Double.parseDouble(constraintAnnotation.maximum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Double value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.doubleValue() < this.maximum || (!exclusive && value.doubleValue() == this.maximum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxFloat.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxFloat.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MaxFloatValidator.class)
+@Documented
+public @interface MaxFloat {
+    String maximum();
+    boolean exclusive();
+    String message() default "Value is bigger than the maximum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxFloatValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxFloatValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MaxFloatValidator implements ConstraintValidator<MaxFloat, Float> {
+
+    private float maximum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MaxFloat constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.maximum = Float.parseFloat(constraintAnnotation.maximum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Float value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.floatValue() < this.maximum || (!exclusive && value.floatValue() == this.maximum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxInteger.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxInteger.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MaxIntegerValidator.class)
+@Documented
+public @interface MaxInteger {
+    String maximum();
+    boolean exclusive();
+    String message() default "Value is bigger than the maximum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxIntegerValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MaxIntegerValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MaxIntegerValidator implements ConstraintValidator<MaxInteger, Integer> {
+
+    private int maximum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MaxInteger constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.maximum = Integer.parseInt(constraintAnnotation.maximum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.intValue() < this.maximum || (!exclusive && value.intValue() == this.maximum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinBigDecimal.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinBigDecimal.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinBigDecimalValidator.class)
+@Documented
+public @interface MinBigDecimal {
+    String minimum();
+    boolean exclusive();
+    String message() default "Value is smaller than the minimum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinBigDecimalValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinBigDecimalValidator.java
@@ -1,0 +1,25 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MinBigDecimalValidator implements ConstraintValidator<MinBigDecimal, BigDecimal> {
+
+    private BigDecimal minimum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MinBigDecimal constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.minimum = new BigDecimal(constraintAnnotation.minimum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(BigDecimal value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.compareTo(this.minimum) > 0 || (!exclusive && value.compareTo(this.minimum) == 0));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinDouble.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinDouble.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinDoubleValidator.class)
+@Documented
+public @interface MinDouble {
+    String minimum();
+    boolean exclusive();
+    String message() default "Value is smaller than the minimum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinDoubleValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinDoubleValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MinDoubleValidator implements ConstraintValidator<MinDouble, Double> {
+
+    private double minimum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MinDouble constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.minimum = Double.parseDouble(constraintAnnotation.minimum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Double value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.doubleValue() > this.minimum || (!exclusive && value.doubleValue() == this.minimum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinFloat.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinFloat.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinFloatValidator.class)
+@Documented
+public @interface MinFloat {
+    String minimum();
+    boolean exclusive();
+    String message() default "Value is smaller than the minimum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinFloatValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinFloatValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MinFloatValidator implements ConstraintValidator<MinFloat, Float> {
+
+    private float minimum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MinFloat constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.minimum = Float.parseFloat(constraintAnnotation.minimum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Float value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.floatValue() > this.minimum || (!exclusive && value.floatValue() == this.minimum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinInteger.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinInteger.java
@@ -1,0 +1,17 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinIntegerValidator.class)
+@Documented
+public @interface MinInteger {
+    String minimum();
+    boolean exclusive();
+    String message() default "Value is smaller than the minimum.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinIntegerValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/MinIntegerValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MinIntegerValidator implements ConstraintValidator<MinInteger, Integer> {
+
+    private int minimum;
+    private boolean exclusive;
+
+    @Override
+    public void initialize(MinInteger constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.minimum = Integer.parseInt(constraintAnnotation.minimum());
+        this.exclusive = constraintAnnotation.exclusive();
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || (value.intValue() > this.minimum || (!exclusive && value.intValue() == this.minimum));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/NotNull.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/NotNull.java
@@ -1,0 +1,18 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NotNullValidator.class)
+@Documented
+public @interface NotNull {
+
+    String message() default "Value is null.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/NotNullValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/NotNullValidator.java
@@ -1,0 +1,18 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Objects;
+
+public class NotNullValidator implements ConstraintValidator<NotNull, Object> {
+
+    @Override
+    public void initialize(NotNull constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        return Objects.nonNull(value);
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/Pattern.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/Pattern.java
@@ -1,0 +1,22 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PatternValidator.class)
+@Documented
+public @interface Pattern {
+
+  String regex();
+
+  String message() default "Value does not fulfill the pattern.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/PatternValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/PatternValidator.java
@@ -1,0 +1,22 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class PatternValidator implements ConstraintValidator<Pattern, String> {
+
+  private String regex;
+
+  @Override
+  public void initialize(Pattern constraintAnnotation) {
+    ConstraintValidator.super.initialize(constraintAnnotation);
+    this.regex = constraintAnnotation.regex();
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+    return Objects.isNull(value) || value.matches(regex);
+  }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/Size.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/Size.java
@@ -1,0 +1,23 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SizeValidator.class)
+@Documented
+public @interface Size {
+
+    int min();
+
+    int max();
+
+    String message() default "Value is not between the correct values.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/SizeValidator.java
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/assets/customvalidator_producer/SizeValidator.java
@@ -1,0 +1,24 @@
+package com.sngular.scsplugin.customvalidatordiff.model.event.producer.customvalidator;
+
+import java.util.Objects;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class SizeValidator implements ConstraintValidator<Size, String> {
+
+    private int min;
+    private int max;
+
+    @Override
+    public void initialize(Size constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return Objects.isNull(value) || ((max == 0 || value.length() <= max) && (min == 0 || value.length() >= min));
+    }
+}

--- a/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/event-api.yml
+++ b/multiapi-engine/src/test/resources/asyncapigenerator/v2/testCustomValidatorsDifferentPackages/event-api.yml
@@ -1,0 +1,56 @@
+asyncapi: 2.5.0
+info:
+  title: Custom Validators Different Packages API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0"
+servers:
+  local-kafka:
+    url: "localhost:9092"
+    protocol: kafka
+channels:
+  clients:
+    publish:
+      operationId: customValidatorClients
+      message:
+        $ref: "#/components/messages/dataClient"
+  response:
+    subscribe:
+      operationId: customValidatorResponse
+      message:
+        $ref: "#/components/messages/status"
+components:
+  messages:
+    status:
+      name: status
+      title: Envia status
+      schemaFormat: application/vnd.aai.asyncapi+json;version=2.0.0
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/data"
+    dataClient:
+      name: dataClient
+      title: Datos del cliente
+      schemaFormat: application/vnd.aai.asyncapi+json;version=2.0.0
+      contentType: application/json
+      payload:
+        $ref: "#/components/schemas/data"
+  schemas:
+    data:
+      type: object
+      required:
+      - clientId
+      - clientName
+      properties:
+        clientId:
+          type: integer
+          minimum: 10
+          maximum: 200
+          description: Id del cliente.
+        clientName:
+          description: Nombre del cliente.
+          type: string
+          minLength: 50
+          maxLength: 200
+          pattern: "^[a-zA-Z0-9_.-]*$"

--- a/multiapi-engine/src/test/resources/openapigenerator/testNoDescriptionRefParameter/api-test.yml
+++ b/multiapi-engine/src/test/resources/openapigenerator/testNoDescriptionRefParameter/api-test.yml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: test
+  version: 11.0.0
+servers:
+- url: https://to_be_defined
+paths:
+  '/test/{testId}':
+    get:
+      tags:
+      - Test
+      summary: test
+      description: test
+      operationId: Retrieve
+      parameters:
+      - $ref: '#/components/parameters/testId'
+      responses:
+        '200':
+          $ref: '#/components/responses/TestResponse'
+components:
+  parameters:
+    testId:
+      name: testId
+      in: path
+      required: true
+      style: simple
+      schema:
+        type: string
+  schemas:
+    TestResponse:
+      type: string
+  responses:
+    TestResponse:
+      description: CustomerPositionStateResponse
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TestResponse'

--- a/multiapi-engine/src/test/resources/openapigenerator/testNoDescriptionRefParameter/assets/TestApi.java
+++ b/multiapi-engine/src/test/resources/openapigenerator/testNoDescriptionRefParameter/assets/TestApi.java
@@ -1,0 +1,46 @@
+package com.sngular.multifileplugin.nodescriptionrefparameter;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.NativeWebRequest;
+
+
+public interface TestApi {
+
+  /**
+   * GET /test/{testId}: test
+   * @param testId true
+   * @return  CustomerPositionStateResponse; (status code 200)
+   */
+
+  @Operation(
+    operationId = "Retrieve",
+    summary = "test",
+    tags = {"Test"},
+    responses = {
+      @ApiResponse(responseCode = "200", description = "CustomerPositionStateResponse", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)))
+    }
+  )
+  @RequestMapping(
+    method = RequestMethod.GET,
+    value = "/test/{testId}",
+    produces = {"application/json"}
+  )
+
+  default ResponseEntity<String> Retrieve(@Parameter(name = "testId", required = true, schema = @Schema(description = "")) @PathVariable("testId") String testId) {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+}

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.7.1'
+version = '6.7.2'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.7.1'
+  implementation 'com.sngular:multiapi-engine:6.7.2'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.7.1'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.7.2'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.7.1</version>
+    <version>6.7.2</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.7.1</version>
+      <version>6.7.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Adds regression tests that confirm two previously-reported issues are already resolved on current `main` (they were fixed indirectly by later refactors; reported against much older versions).

Closes #251
Closes #277

## #251 — [OpenApi] API code not generated when a `$ref` path parameter has no description (reported on 4.8.5)

New end-to-end fixture `testNoDescriptionRefParameterGeneration` uses the exact spec from the issue (`/test/{testId}` with a `$ref` to `#/components/parameters/testId`, no `description`, response `$ref` to `#/components/responses/TestResponse`). It asserts the API file is generated with the `@PathVariable` parameter.

## #277 — [AsyncAPI] custom validators only generated in one model package when consumer/supplier use different `modelPackage`

New fixture `testCustomValidatorsDifferentPackages` configures the consumer and supplier with different `modelPackage`s, both referencing the same schema (`data`) that has constraints (required, min/max, pattern, size). It asserts the `customvalidator` folder is generated with the full set of annotation + validator classes in **both** the consumer and producer packages, and that each `DataDTO` imports them from its own package.

## Validation

- `multiapi-engine`: full suite green — **133 tests, 0 failures** (was 131 before these two cases).
- Version bumped to **6.7.2** in all three modules (engine, Maven plugin, Gradle plugin).