### PR TITLE
Fix #339: support useTimeType and common spec fields in Gradle AsyncAPI plugin (6.7.3)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -17,4 +17,5 @@
 exclude_paths:
   - 'scs-multiapi-gradle-plugin/src/main/groovy/com/sngular/api/generator/plugin/*Task.groovy'
   - 'scs-multiapi-gradle-plugin/src/main/groovy/com/sngular/api/generator/plugin/model/*SpecFile.groovy'
+  - 'scs-multiapi-gradle-plugin/src/main/groovy/com/sngular/api/generator/plugin/model/OperationParameter.groovy'
   - '**/src/test/resources/**'

--- a/multiapi-engine/pom.xml
+++ b/multiapi-engine/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>multiapi-engine</artifactId>
-  <version>6.7.2</version>
+  <version>6.7.3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/scs-multiapi-gradle-plugin/build.gradle
+++ b/scs-multiapi-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = 'com.sngular'
-version = '6.7.2'
+version = '6.7.3'
 
 def SCSMultiApiPluginGroupId = group
 def SCSMultiApiPluginVersion = version
@@ -31,7 +31,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation 'com.sngular:multiapi-engine:6.7.2'
+  implementation 'com.sngular:multiapi-engine:6.7.3'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'com.puppycrawl.tools:checkstyle:10.12.3'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.2'
@@ -100,7 +100,7 @@ testing {
 
     integrationTest(JvmTestSuite) {
       dependencies {
-        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.7.2'
+        implementation 'com.sngular:scs-multiapi-gradle-plugin:6.7.3'
         implementation 'org.assertj:assertj-core:3.24.2'
       }
 

--- a/scs-multiapi-gradle-plugin/src/main/groovy/com/sngular/api/generator/plugin/AsyncApiTask.groovy
+++ b/scs-multiapi-gradle-plugin/src/main/groovy/com/sngular/api/generator/plugin/AsyncApiTask.groovy
@@ -92,11 +92,26 @@ abstract class AsyncApiTask extends DefaultTask {
     if (parameterObject.getIds()) {
       builder.ids(parameterObject.ids)
     }
+    if (parameterObject.getModelNamePrefix()) {
+      builder.modelNamePrefix(parameterObject.modelNamePrefix)
+    }
     if (parameterObject.getModelNameSuffix()) {
       builder.modelNameSuffix(parameterObject.modelNameSuffix)
     }
     if (parameterObject.getModelPackage()) {
       builder.modelPackage(parameterObject.modelPackage)
+    }
+    if (parameterObject.getDateFormat()) {
+      builder.dateFormat(parameterObject.dateFormat)
+    }
+    if (parameterObject.getDateTimeFormat()) {
+      builder.dateTimeFormat(parameterObject.dateTimeFormat)
+    }
+    if (parameterObject.getUseTimeType()) {
+      builder.useTimeType(parameterObject.useTimeType)
+    }
+    if (parameterObject.getUseLombokModelAnnotation()) {
+      builder.useLombokModelAnnotation(parameterObject.useLombokModelAnnotation)
     }
 
     return builder.build()

--- a/scs-multiapi-gradle-plugin/src/main/groovy/com/sngular/api/generator/plugin/model/OperationParameter.groovy
+++ b/scs-multiapi-gradle-plugin/src/main/groovy/com/sngular/api/generator/plugin/model/OperationParameter.groovy
@@ -6,6 +6,8 @@
 
 package com.sngular.api.generator.plugin.model
 
+import com.sngular.api.generator.plugin.common.model.TypeConstants
+
 class OperationParameter {
 
   String ids
@@ -14,9 +16,19 @@ class OperationParameter {
 
   String modelPackage
 
+  String modelNamePrefix
+
   String modelNameSuffix
 
   String classNamePostfix
+
+  String dateFormat
+
+  String dateTimeFormat
+
+  TypeConstants.TimeType useTimeType
+
+  boolean useLombokModelAnnotation
 
   String getIds() {
     return ids
@@ -46,6 +58,14 @@ class OperationParameter {
     this.modelPackage = modelPackage
   }
 
+  String getModelNamePrefix() {
+    return modelNamePrefix
+  }
+
+  void setModelNamePrefix(final String modelNamePrefix) {
+    this.modelNamePrefix = modelNamePrefix
+  }
+
   String getModelNameSuffix() {
     return modelNameSuffix
   }
@@ -60,6 +80,38 @@ class OperationParameter {
 
   void setClassNamePostfix(final String classNamePostfix) {
     this.classNamePostfix = classNamePostfix
+  }
+
+  String getDateFormat() {
+    return dateFormat
+  }
+
+  void setDateFormat(final String dateFormat) {
+    this.dateFormat = dateFormat
+  }
+
+  String getDateTimeFormat() {
+    return dateTimeFormat
+  }
+
+  void setDateTimeFormat(final String dateTimeFormat) {
+    this.dateTimeFormat = dateTimeFormat
+  }
+
+  TypeConstants.TimeType getUseTimeType() {
+    return useTimeType
+  }
+
+  void setUseTimeType(final TypeConstants.TimeType useTimeType) {
+    this.useTimeType = useTimeType
+  }
+
+  boolean getUseLombokModelAnnotation() {
+    return useLombokModelAnnotation
+  }
+
+  void setUseLombokModelAnnotation(final boolean useLombokModelAnnotation) {
+    this.useLombokModelAnnotation = useLombokModelAnnotation
   }
 
 }

--- a/scs-multiapi-gradle-plugin/src/test/java/com/sngular/api/generator/plugin/ScsMultiApiTest.java
+++ b/scs-multiapi-gradle-plugin/src/test/java/com/sngular/api/generator/plugin/ScsMultiApiTest.java
@@ -8,8 +8,10 @@ package com.sngular.api.generator.plugin;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.sngular.api.generator.plugin.asyncapi.parameter.OperationParameterObject;
 import com.sngular.api.generator.plugin.common.model.TypeConstants;
 import com.sngular.api.generator.plugin.model.OpenApiSpecFile;
+import com.sngular.api.generator.plugin.model.OperationParameter;
 import com.sngular.api.generator.plugin.openapi.parameter.SpecFile;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -52,6 +54,49 @@ class ScsMultiApiTest {
     final SpecFile result = (SpecFile) OpenApiTask.toFileSpec(specFile);
 
     assertEquals(TypeConstants.TimeType.LOCAL, result.getUseTimeType());
+  }
+
+  @Test
+  void asyncApiTaskMapsUseTimeType() {
+    final OperationParameter parameterObject = new OperationParameter();
+    parameterObject.setUseTimeType(TypeConstants.TimeType.ZONED);
+
+    final OperationParameterObject result = AsyncApiTask.toOperationParameterObject(parameterObject);
+
+    assertEquals(TypeConstants.TimeType.ZONED, result.getUseTimeType());
+  }
+
+  @Test
+  void asyncApiTaskDefaultsUseTimeTypeToLocal() {
+    final OperationParameter parameterObject = new OperationParameter();
+
+    final OperationParameterObject result = AsyncApiTask.toOperationParameterObject(parameterObject);
+
+    assertEquals(TypeConstants.TimeType.LOCAL, result.getUseTimeType());
+  }
+
+  @Test
+  void asyncApiTaskMapsCommonSpecFileFields() {
+    final OperationParameter parameterObject = new OperationParameter();
+    parameterObject.setApiPackage("com.example.api");
+    parameterObject.setModelPackage("com.example.model");
+    parameterObject.setModelNamePrefix("Prefix");
+    parameterObject.setModelNameSuffix("DTO");
+    parameterObject.setClassNamePostfix("Consumer");
+    parameterObject.setDateFormat("dd/MM/yyyy");
+    parameterObject.setDateTimeFormat("dd/MM/yyyy HH:mm");
+    parameterObject.setUseLombokModelAnnotation(true);
+
+    final OperationParameterObject result = AsyncApiTask.toOperationParameterObject(parameterObject);
+
+    assertEquals("com.example.api", result.getApiPackage());
+    assertEquals("com.example.model", result.getModelPackage());
+    assertEquals("Prefix", result.getModelNamePrefix());
+    assertEquals("DTO", result.getModelNameSuffix());
+    assertEquals("Consumer", result.getClassNamePostfix());
+    assertEquals("dd/MM/yyyy", result.getDateFormat());
+    assertEquals("dd/MM/yyyy HH:mm", result.getDateTimeFormat());
+    assertTrue(result.isUseLombokModelAnnotation());
   }
 
 }

--- a/scs-multiapi-maven-plugin/pom.xml
+++ b/scs-multiapi-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sngular</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-    <version>6.7.2</version>
+    <version>6.7.3</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>
@@ -271,7 +271,7 @@
     <dependency>
       <groupId>com.sngular</groupId>
       <artifactId>multiapi-engine</artifactId>
-      <version>6.7.2</version>
+      <version>6.7.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Fixes #339

## Problem

The **Gradle** AsyncAPI plugin failed with `Could not set unknown property 'useTimeType' for object of type com.sngular.api.generator.plugin.model.OperationParameter` when configuring `useTimeType` (or `dateFormat`, `dateTimeFormat`, `useLombokModelAnnotation`, `modelNamePrefix`) inside `consumer` / `supplier` / `streamBridge`.

`OperationParameter.groovy` only exposed `ids`, `apiPackage`, `modelPackage`, `modelNameSuffix`, `classNamePostfix`, and `AsyncApiTask.toOperationParameterObject` only mapped those — even though the engine's `OperationParameterObject` (which extends `CommonSpecFile`) supports all these fields, the docs document them, and the **OpenAPI** Gradle plugin already maps them (`OpenApiTask.toFileSpec`).

## Fix

- `scs-multiapi-gradle-plugin/.../model/OperationParameter.groovy`: added `modelNamePrefix`, `dateFormat`, `dateTimeFormat`, `useTimeType` (`TypeConstants.TimeType`) and `useLombokModelAnnotation`, mirroring `CommonSpecFile`.
- `scs-multiapi-gradle-plugin/.../AsyncApiTask.groovy`: `toOperationParameterObject` now maps the new fields onto `OperationParameterObject`.
- `ScsMultiApiTest.java`: added 4 tests — `useTimeType` mapping (ZONED), default (LOCAL), and mapping of the remaining common spec fields.
- `.codacy.yml`: added `OperationParameter.groovy` to `exclude_paths`, consistent with the other Gradle DSL model classes (`*SpecFile.groovy`, `*Task.groovy`) that are already excluded because CodeNarc's default rules (e.g. 4-space `Indentation`, missing Javadoc) flag this project's 2-space Groovy convention as noise.

## Validation

- `scs-multiapi-gradle-plugin`: `gradlew test` green — **7 tests, 0 failures** (was 3).
- `multiapi-engine`: full suite green — **133 tests, 0 failures**.
- Reproduced the Codacy findings locally with CodeNarc 3.3.0 (all violations in `OperationParameter.groovy` are the known Indentation/Javadoc-style noise; the file is now excluded like its siblings).
- Version bumped to **6.7.3** in all three modules (engine, Maven plugin, Gradle plugin).